### PR TITLE
Updated Grunt tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,12 +88,14 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					port: port,
-					base: '.'
+					base: '.',
+					keepalive: true,
+					debug: true
 				}
 			}
 		},
 		notify: {
-			connect: {
+			watch: {
 				options: {
 					// title: 'Watching files',  // optional
 					message: 'Watching for changes' //required
@@ -128,8 +130,10 @@ module.exports = function(grunt) {
 	grunt.registerTask('default', ['jshint', 'concat', 'notify:finish']);
 
 	// Serve examples locally
-	grunt.registerTask('serve', ['connect', 'notify:connect', 'watch']);
+	grunt.registerTask('serve', ['connect']);
+
+	// Build files and refresh content on file changes
+	grunt.registerTask('dev', ['default', 'notify:watch', 'watch']);
 
 	grunt.task.run('notify_hooks');
-
 };

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ grunt serve
 
 Then open [http://127.0.0.1:8000/examples](http://127.0.0.1:8000/examples)
 
+#### Build ViziCities and watch for file changes using Grunt
+```
+cd /path/to/vizicities
+grunt dev
+```
+
 ### Data formats
 
 Visualising geographic features lies at the core of ViziCities. To make sure features render correctly you'll need to [use the correct data formats](https://github.com/robhawkes/vizicities/blob/master/DATA-FORMATTING.md).


### PR DESCRIPTION
There is now a `grunt dev` task to build and watch for files changes. `grunt serve` now only serves content.
