### PR TITLE
Add charset to example index.html

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -2,6 +2,7 @@
 
 <html>
 <head>
+	<meta charset="utf-8">
 	<title>ViziCities Architecture Example</title>
 
 	<link href="reset.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
Add charset to example index.html to avoid `Unexpected token ILLEGAL` error due to utf-8 characters (Ï€ etc.) in the javascript
![image](https://f.cloud.github.com/assets/345235/2182307/39ebf0ac-9784-11e3-9235-3cd70ad3c154.png)
