### PR TITLE
Added hostname

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -102,6 +102,8 @@ module.exports = function(grunt) {
 			server: {
 				options: {
 					port: port,
+					// change hostname to 0.0.0.0 to open it up
+                                        hostname: 'localhost',
 					base: '.',
 					keepalive: true,
 					debug: true


### PR DESCRIPTION
To run vizicities on an external server (for example on Amazon EC2) you need to introduce the hostname which defaults to 'localhost'. To open the server for any IP address, one needs to enter either the external IP or '0.0.0.0'.
