### PR TITLE
Option for enabling controls

### DIFF
--- a/src/client/City.js
+++ b/src/client/City.js
@@ -12,6 +12,9 @@
 		this.fps = undefined;
 		this.rendererInfo = undefined;
 
+		// Options
+		this.options = undefined;
+
 		// UI
 		this.ui = {};
 		this.ui.loading = undefined;
@@ -55,6 +58,8 @@
 			options = {};
 		}
 
+		this.options = options;
+
 		var hash = window.location.hash.replace('#', '');
 		var coordCheck = /^(\-?\d+(\.\d+)?),(\-?\d+(\.\d+)?)$/;
 		if (coordCheck.test(hash) && !_.has(options, 'coords')) {
@@ -62,7 +67,8 @@
 		}
 
 		_.defaults(options, {
-			coords: [-0.01924, 51.50358]
+			coords: [-0.01924, 51.50358],
+			controls: { enable: true }
 		});
 
 		// Output city options
@@ -211,7 +217,7 @@
 
 		this.controls = VIZI.Controls.getInstance();
 
-		this.controls.init(this.webgl.camera).then(function(result) {
+		this.controls.init(this.webgl.camera, this.options.controls).then(function(result) {
 			VIZI.Log("Finished intialising controls in " + (Date.now() - startTime) + "ms");
 
 			deferred.resolve();

--- a/src/client/controls/Controls.js
+++ b/src/client/controls/Controls.js
@@ -8,16 +8,21 @@
 
 			_.extend(this, VIZI.Mediator);
 
+			this.enabled = undefined;
+
 			this.mouse = undefined;
 			this.keyboard = undefined;
 		};
 
-		Controls.prototype.init = function(camera) {
-			this.mouse = VIZI.Mouse.getInstance(camera);
-			this.keyboard = VIZI.Keyboard.getInstance();
+		Controls.prototype.init = function(camera, options) {
+			if (options.enable) {
+				this.mouse = VIZI.Mouse.getInstance(camera);
+				this.keyboard = VIZI.Keyboard.getInstance();
 
-			this.subscribe("update", this.onUpdate);
-			this.subscribe("orbitControlCap", this.orbitCapReset);
+				this.subscribe("update", this.onUpdate);
+				this.subscribe("orbitControlCap", this.orbitCapReset);
+			}
+			this.enabled = options.enable;
 
 			return Q.fcall(function() {});
 		};


### PR DESCRIPTION
Added option whether or not to enable controls, passed to City init. Defaults to enabled.

Resolves #43.

Later, would probably want to be able to toggle controls post-init, say from a UI button.
