### PR TITLE
Force reload on hash change

### DIFF
--- a/src/client/City.js
+++ b/src/client/City.js
@@ -41,6 +41,8 @@
 		this.loop = undefined;
 
 		this.publish("addToDat", this, {name: "City", properties: ["init"]});
+
+		this.subscribe("hashchange", this.onHashchange);
 	};
 
 	VIZI.City.prototype.init = function(options) {
@@ -57,8 +59,8 @@
 
 		var hash = window.location.hash.replace('#', '');
 		var coordCheck = /^(\-?\d+(\.\d+)?),(\-?\d+(\.\d+)?)$/;
-		if (coordCheck.test(hash) && !_.has(options, 'coords')) {
-			options.coords = hash.split(',');
+		if (coordCheck.test(hash)) {
+			options.coords = hash.split(',').reverse();
 		}
 
 		_.defaults(options, {
@@ -264,4 +266,9 @@
 
 		return deferred.promise;
 	};
+
+	VIZI.City.prototype.onHashchange = function(){
+		window.location.reload();
+	};
+
 }());

--- a/src/client/DOMEvents.js
+++ b/src/client/DOMEvents.js
@@ -19,6 +19,11 @@
 			self.publish("resize", event);
 		}, false );
 
+		// Hash change
+		window.addEventListener( "hashchange", function(event) {
+			self.publish("hashchange", event);
+		}, false );
+
 		return Q.fcall(function() {});
 	};
 }());


### PR DESCRIPTION
Reload seems like a heavy solution but haven't quite cracked nicely moving to a new location by only updating the relative minimum.

Additionally, reversed coordinate order. 
