### PR TITLE
Fixing Safari zoom issue

### DIFF
--- a/src/client/controls/Mouse.js
+++ b/src/client/controls/Mouse.js
@@ -50,12 +50,13 @@
 				self.onMouseUp(event);
 			}, false);
 
-			document.addEventListener("wheel", function(event) {
-				self.onMouseWheel(event);
-			}, false);
+			// Prefer wheel event, but fallback to mousewheel event if necessary
+			var wheel_event = "wheel"; 
+			if (window.onwheel === undefined) {
+				wheel_event = "mousewheel"; 
+			}
 
-			// Safari
-			document.addEventListener("mousewheel", function(event) {
+			document.addEventListener(wheel_event, function(event) {
 				self.onMouseWheel(event);
 			}, false);
 
@@ -159,7 +160,18 @@
 
 			var state = this.state;
 
-			state.wheelDelta -= event.deltaY !== undefined ? event.deltaY : event.wheelDeltaY;
+			// Wheel event 
+			if (event.deltaY !== undefined) {
+
+				state.wheelDelta -= event.deltaY;
+			
+			// MouseWheel Event 
+			} else {
+
+				state.wheelDelta += event.wheelDeltaY;
+
+			}
+
 		};
 
 		Mouse.prototype.resetDelta = function() {


### PR DESCRIPTION
Issue #33 fixed scrolling on Firefox, but it appears that Safari 7.0.2 still doesn't support the onwheel event, although it does support the old onmousewheel event. Added a fallback to use the onmousewheel event if window.onwheel is undefined (and also handle the deltaY/wheelDeltaY +/- event differences) so you can zoom in Safari.
