### PR TITLE
Make camera more configurable

### DIFF
--- a/src/client/City.js
+++ b/src/client/City.js
@@ -70,8 +70,7 @@
 
 		_.defaults(options, {
 			coords: [-0.01924, 51.50358],
-			capZoom: true,
-			capOrbit: true,
+			camera: {},
 			overpass: true,
 			overpassGridUpdate: true,
 			overpassWayIntersect: false,
@@ -192,10 +191,12 @@
 		var startTime = Date.now();
 
 		var deferred = Q.defer();
-		
 		this.webgl = new VIZI.WebGL();
 
-		this.webgl.init(this.geo.centerPixels, options.capZoom, options.capOrbit).then(function(result) {
+		_.defaults(options.camera, {
+			target: this.geo.centerPixels
+		});
+		this.webgl.init(options).then(function(result) {
 			VIZI.Log("Finished intialising WebGL in " + (Date.now() - startTime) + "ms");
 
 			deferred.resolve();

--- a/src/client/webgl/WebGL.js
+++ b/src/client/webgl/WebGL.js
@@ -15,10 +15,10 @@
 		this.lights = [];
 	};
 
-	VIZI.WebGL.prototype.init = function(cameraTargetPos, capZoom, capOrbit) {
+	VIZI.WebGL.prototype.init = function(options) {
 		this.domContainer = this.createDOMContainer();
 		this.scene = new VIZI.Scene();
-		this.camera = new VIZI.Camera(cameraTargetPos, capZoom, capOrbit);
+		this.camera = new VIZI.Camera(options.camera);
 		this.renderer = new VIZI.Renderer(this.scene, this.camera, this.domContainer);
 
 		this.lights = [];


### PR DESCRIPTION
I want to control the camera better. This PR makes all magic numbers in camera configurable through a unified options parameter.

An example how to configure the camera:

```
city.init({camera: {capZoom: false, cameraFov: 70}})
```

`camera.load` and `camera.serialize` can be used to load new options or serialize the existing state.
