### PR TITLE
Always return the promise in loadProcess

### DIFF
--- a/src/client/data/Data.js
+++ b/src/client/data/Data.js
@@ -131,7 +131,7 @@
 		if (uniqueFeatures.length === 0) {
 			VIZI.Log("No features left to pass to worker");
 			deferred.resolve();
-			return;
+			return deferred.promise;
 		}
 
 		// TODO: Pass-through progress event


### PR DESCRIPTION
returning undefined leads to error thrown in `self.loadProcess(...).done()` (because `undefined.done` is not a function)
