### PR TITLE
0.2.0: Refactoring for more flexible configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js:
   - "0.10"
 before_install:
   - npm install -g grunt-cli
+  - npm install -g bower
+  - bower install
 notifications:
   webhooks:
     urls:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -111,7 +111,17 @@ module.exports = function(grunt) {
         },
         src: ["test/*.html"]
       }
-    }
+    },
+    connect: {
+      dev: {
+        options: {
+          port: 8989,
+          keepalive: true,
+          base: "./",
+          open: (grunt.option("no-browser") ? false : "http://localhost:8989/examples/basic-example/index.html")
+        }
+      }
+    },
   });
 
   // Load the plugins
@@ -119,6 +129,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks("grunt-mocha-slimer");
   grunt.loadNpmTasks("grunt-contrib-concat");
   grunt.loadNpmTasks("grunt-contrib-uglify");
+  grunt.loadNpmTasks("grunt-contrib-connect");
 
   // Default task(s).
   grunt.registerTask("default", ["test"]);
@@ -127,6 +138,9 @@ module.exports = function(grunt) {
   // TODO: If tests keep failing randomly on Travis then move back to Phantom
   // - Just means absolute zero chance of WebGL testing then
   grunt.registerTask("test", ["jshint", "mocha_slimer"]);
+
+  // Development
+  grunt.registerTask("dev", ["connect:dev"]);
 
   // Build
   grunt.registerTask("build", ["concat:vizicities", "uglify:vizicities", "concat:bower", "concat:bower_min"]);

--- a/examples/customization/index.html
+++ b/examples/customization/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta http-equiv="Content-type" content="text/html; charset=utf-8">
+  <title>ViziCities - Basic Example</title>
+
+  <style type="text/css">
+    html, body {
+      height: 100%;
+      width: 100%;
+    }
+
+    body {
+      background: #222;
+      margin: 0;
+      overflow: hidden;
+      padding: 0;
+    }
+
+    #vizicities-viewport {
+      height: 720px;
+      left: 50%;
+      margin: -360px 0 0 -640px;
+      position: absolute;
+      top: 50%;
+      width: 1280px;
+    }
+  </style>
+
+  <link rel="stylesheet" type="text/css" href="../../build/vizi.css">
+</head>
+<body>
+  <div id="vizicities-viewport"></div>
+  <script src="../../build/vizi.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/customization/main.js
+++ b/examples/customization/main.js
@@ -1,0 +1,210 @@
+
+// Custom VIZI.Scene
+
+var CustomScene = function(options) {
+  this.scene = new THREE.Scene();
+  this.t = 0.0;
+};
+
+CustomScene.prototype = Object.create( VIZI.Scene.prototype );
+
+CustomScene.prototype.init = function(options) {
+  this.directionalLight = new THREE.DirectionalLight("rgb(200,200,200)", 1);
+  this.directionalLight.position.set(1,0.5,-0.5);
+
+  this.pointLight = new THREE.PointLight("red", 10, 300);
+  this.pointLight.position.set(-200, 100, 200);
+
+  this.indicatorMesh = new THREE.Mesh(
+    new THREE.SphereGeometry(30, 32, 32),
+    new THREE.MeshLambertMaterial({ color : "red" })
+  );
+
+  this.add(this.directionalLight);
+  this.add(this.pointLight);
+  this.add(this.indicatorMesh);
+};
+
+CustomScene.prototype.add = function(object) {
+  this.scene.add(object);
+};
+
+CustomScene.prototype.remove = function(object) {
+  this.scene.remove(object);
+};
+
+CustomScene.prototype.onTick = function(delta) {
+  this.t += delta / 10;
+  if (this.t <= 1.0) {
+    this.pointLight.position.copy(new THREE.Vector3(-200, 100, 200).lerp(new THREE.Vector3(200, 150, -200), this.t));
+  }
+  else {
+    this.pointLight.position.set(-200, 100, 200);
+    this.t = 0.0;
+  }
+  this.indicatorMesh.position.copy(this.pointLight.position);
+};
+
+// Initilize VIZI.World with customizations
+
+var world = new VIZI.World({
+  viewport: document.querySelector("#vizicities-viewport"),
+  scene: new CustomScene(),
+  renderer: { antialias : true }
+});
+
+var controls = new VIZI.ControlsMap(world.camera);
+
+var mapConfig = {
+  input: {
+    type: "BlueprintInputMapTiles",
+    options: {
+      tilePath: "https://a.tiles.mapbox.com/v3/examples.map-i86l3621/{z}/{x}/{y}@2x.png"
+    }
+  },
+  output: {
+    type: "BlueprintOutputImageTiles",
+    options: {
+      grids: [{
+        zoom: 19,
+        tilesPerDirection: 3,
+        cullZoom: 17
+      }, {
+        zoom: 18,
+        tilesPerDirection: 3,
+        cullZoom: 16
+      }, {
+        zoom: 17,
+        tilesPerDirection: 3,
+        cullZoom: 15
+      }, {
+        zoom: 16,
+        tilesPerDirection: 3,
+        cullZoom: 14
+      }, {
+        zoom: 15,
+        tilesPerDirection: 3,
+        cullZoom: 13
+      }, {
+        zoom: 14,
+        tilesPerDirection: 3,
+        cullZoom: 12
+      }, {
+        zoom: 13,
+        tilesPerDirection: 5,
+        cullZoom: 11
+      }]
+    }
+  },
+  triggers: [{
+    triggerObject: "output",
+    triggerName: "initialised",
+    triggerArguments: ["tiles"],
+    actionObject: "input",
+    actionName: "requestTiles",
+    actionArguments: ["tiles"],
+    actionOutput: {
+      tiles: "tiles" // actionArg: triggerArg
+    }
+  }, {
+    triggerObject: "output",
+    triggerName: "gridUpdated",
+    triggerArguments: ["tiles"],
+    actionObject: "input",
+    actionName: "requestTiles",
+    actionArguments: ["tiles"],
+    actionOutput: {
+      tiles: "tiles" // actionArg: triggerArg
+    }
+  }, {
+    triggerObject: "input",
+    triggerName: "tileReceived",
+    triggerArguments: ["image", "tile"],
+    actionObject: "output",
+    actionName: "outputImageTile",
+    actionArguments: ["image", "tile"],
+    actionOutput: {
+      image: "image", // actionArg: triggerArg
+      tile: "tile"
+    }
+  }]
+};
+
+var switchboardMap = new VIZI.BlueprintSwitchboard(mapConfig);
+switchboardMap.addToWorld(world);
+
+var buildingsConfig = {
+  input: {
+    type: "BlueprintInputGeoJSON",
+    options: {
+      tilePath: "http://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.json"
+    }
+  },
+  output: {
+    type: "BlueprintOutputBuildingTiles",
+    options: {
+      grids: [{
+        zoom: 15,
+        tilesPerDirection: 1,
+        cullZoom: 13
+      }],
+      workerURL: "../../build/vizi-worker.min.js"
+    }
+  },
+  triggers: [{
+    triggerObject: "output",
+    triggerName: "initialised",
+    triggerArguments: ["tiles"],
+    actionObject: "input",
+    actionName: "requestTiles",
+    actionArguments: ["tiles"],
+    actionOutput: {
+      tiles: "tiles" // actionArg: triggerArg
+    }
+  }, {
+    triggerObject: "output",
+    triggerName: "gridUpdated",
+    triggerArguments: ["tiles"],
+    actionObject: "input",
+    actionName: "requestTiles",
+    actionArguments: ["tiles"],
+    actionOutput: {
+      tiles: "tiles" // actionArg: triggerArg
+    }
+  }, {
+    triggerObject: "input",
+    triggerName: "tileReceived",
+    triggerArguments: ["geoJSON", "tile"],
+    actionObject: "output",
+    actionName: "outputBuildingTile",
+    actionArguments: ["buildings", "tile"],
+    actionOutput: {
+      buildings: {
+        process: "map",
+        itemsObject: "geoJSON",
+        itemsProperties: "features",
+        transformation: {
+          outline: "geometry.coordinates",
+          height: "properties.height"
+        }
+      },
+      tile: "tile"
+    }
+  }]
+};
+
+var switchboardBuildings = new VIZI.BlueprintSwitchboard(buildingsConfig);
+switchboardBuildings.addToWorld(world);
+
+var clock = new VIZI.Clock();
+
+var update = function() {
+  var delta = clock.getDelta();
+  world.onTick(delta);
+  world.scene.onTick(delta);
+  world.render();
+
+  window.requestAnimationFrame(update);
+};
+
+update();

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "chai": "^1.9.2",
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.0",
+    "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-mocha-slimer": "0.0.2",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "grunt build && grunt build_worker && grunt test --verbose"
+    "test": "grunt build && grunt test --verbose"
   },
   "repository": {
     "type": "git",
@@ -32,6 +32,7 @@
   "devDependencies": {
     "chai": "^1.9.2",
     "grunt": "^0.4.5",
+    "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-concat": "^0.5.0",
     "grunt-contrib-connect": "^0.9.0",
     "grunt-contrib-jshint": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "grunt test --verbose"
+    "test": "grunt build && grunt build_worker && grunt test --verbose"
   },
   "repository": {
     "type": "git",

--- a/src/WebGL/Camera.js
+++ b/src/WebGL/Camera.js
@@ -12,27 +12,31 @@
     if (VIZI.DEBUG) console.log("Initialising VIZI.Camera");
 
     var self = this;
-
     self.options = options || {};
-    
+
     _.defaults(self.options, {
-      fov: 40,
-      near: 2,
-      far: 40000,
-      position: new VIZI.Point(260, 600, 550),
-      target: new VIZI.Point()
+      aspect   : 1/2,
+      fov      : 40,
+      near     : 2,
+      far      : 40000,
+      position : new VIZI.Point(260, 600, 550),
+      target   : new VIZI.Point(0, 0, 0)
     });
 
-    if (!self.options.aspect) {
-      throw new Error("Required aspect option missing");
-    }
-
-    self.camera = new THREE.PerspectiveCamera(self.options.fov, self.options.aspect, self.options.near, self.options.far);
+    self.camera = new THREE.PerspectiveCamera(
+      self.options.fov, self.options.aspect,
+      self.options.near, self.options.far
+    );
 
     // It's assumed that you'd want to do this after adding a camera
     // TODO: Consider if calling lookAt() here is a step too far and should be left to the user
     self.moveTo(self.options.position);
     self.lookAt(self.options.target);
+  };
+
+  VIZI.Camera.prototype.init = function(options) {
+    if (options.viewport !== undefined)
+      this.changeAspect(options.viewport.clientWidth / options.viewport.clientHeight);
   };
 
   VIZI.Camera.prototype.addToScene = function(scene) {

--- a/src/WebGL/Renderer.js
+++ b/src/WebGL/Renderer.js
@@ -1,0 +1,70 @@
+/* globals window, _, VIZI, THREE */
+
+/**
+ * 3D scene renderer
+ * @author Robin Hawkes - vizicities.com
+ */
+
+(function() {
+  "use strict";
+
+  VIZI.Renderer = function(options) {
+    if (VIZI.DEBUG) console.log("Initialising VIZI.Renderer");
+
+    var self = this;
+    self.options = options || {};
+
+    _.defaults(self.options, {
+      headless   : false,
+      antialias  : false,
+      fogColour  : 0xffffff
+    });
+
+    if (self.options.headless !== true) {
+      self.renderer = new THREE.WebGLRenderer({
+        antialias: self.options.antialias
+      });
+    } else {
+      self.renderer = {
+        render        : function() {},
+        setSize       : function() {},
+        setClearColor : function() {}
+      };
+    }
+  };
+
+  VIZI.Renderer.prototype.init = function(options) {
+    var self = this;
+    
+    if (self.options.headless === true)
+      return;
+    else if (!options.viewport)
+       throw new Error("VIZI.Renderer.init: Required viewport option missing");
+
+    // Gamma settings make things look 'nicer' for some reason
+    self.renderer.gammaInput = true;
+    self.renderer.gammaOutput = true;
+      
+    self.renderer.setSize(options.viewport.clientWidth, options.viewport.clientHeight);
+    self.renderer.setClearColor(self.options.fogColour, 1);
+
+    options.viewport.appendChild(self.renderer.domElement);
+  };
+
+  VIZI.Renderer.prototype.render = function(scene, camera) {
+    var self = this;
+
+    if (!scene)
+      throw new Error("VIZI.Renderer.render: Scene is required for rendering");
+    else if (!camera)
+      throw new Error("VIZI.Renderer.render: Camera is required for rendering");
+
+    self.renderer.render(scene.scene, camera.camera);
+  };
+
+  VIZI.Renderer.prototype.resize = function(width, height) {
+    var self = this;
+
+    self.renderer.setSize(width, height);
+  };
+})();

--- a/src/WebGL/Scene.js
+++ b/src/WebGL/Scene.js
@@ -12,41 +12,30 @@
     if (VIZI.DEBUG) console.log("Initialising VIZI.Scene");
 
     var self = this;
-
     self.options = options || {};
-    
-    _.defaults(self.options, {
-      antialias: false,
-      fogColour: 0xffffff,
-      suppressRenderer: false
-    });
 
-    if (!self.options.viewport) {
-      throw new Error("Required viewport option missing");
-    }
-
-    self.scene = self.createScene();
-    self.renderer = self.createRenderer();
+    self.scene = new THREE.Scene();
   };
 
-  VIZI.Scene.prototype.createScene = function() {
+  VIZI.Scene.prototype.init = function(options) {
     var self = this;
 
-    var scene = new THREE.Scene();
+    // TODO: Make configurable via startup options.scene
+    // * Fog distance
+    // * If dir lights should be added and its color (day/night color separately?)
+    // * If ambient light should be added and its color
 
-    // TODO: Fog distance should be an option
-    scene.fog = new THREE.Fog(self.options.fogColour, 1, 15000);
+    // Fog color is present if not a custom renderer
+    if (options !== undefined && options.renderer.options !== undefined && options.renderer.options.fogColour !== undefined)
+      self.scene.fog = new THREE.Fog(options.renderer.options.fogColour, 1, 15000);
 
-    // TODO: Make this more customisable, perhaps as a "day/night" option
-    // - I'm sure people would want to add their own lighting too
-    // TODO: Should this even be in here?
     var directionalLight = new THREE.DirectionalLight( 0x999999 );
     directionalLight.intesity = 0.1;
     directionalLight.position.x = 1;
     directionalLight.position.y = 1;
     directionalLight.position.z = 1;
 
-    scene.add(directionalLight);
+    self.scene.add(directionalLight);
 
     var directionalLight2 = new THREE.DirectionalLight( 0x999999 );
     directionalLight2.intesity = 0.1;
@@ -54,41 +43,7 @@
     directionalLight2.position.y = 1;
     directionalLight2.position.z = -1;
 
-    scene.add(directionalLight2);
-    
-    return scene;
-  };
-
-  VIZI.Scene.prototype.createRenderer = function() {
-    var self = this;
-
-    var renderer;
-
-    if (self.options.suppressRenderer) {
-      // Mock renderer for tests
-      // TODO: Should really remove this or fix the tests
-      renderer = {
-        setSize: function(){},
-        setClearColor: function(){},
-        render: function(){},
-        domElement: document.createElement("canvas")
-      };
-    } else {
-      renderer = new THREE.WebGLRenderer({
-        antialias: self.options.antialias
-      });
-    }
-
-    renderer.setSize(self.options.viewport.clientWidth, self.options.viewport.clientHeight);
-    renderer.setClearColor(self.scene.fog.color, 1);
-
-    // Gamma settings make things look 'nicer' for some reason
-    renderer.gammaInput = true;
-    renderer.gammaOutput = true;
-
-    self.options.viewport.appendChild(renderer.domElement);
-
-    return renderer;
+    self.scene.add(directionalLight2);
   };
 
   VIZI.Scene.prototype.add = function(object) {
@@ -99,24 +54,5 @@
   VIZI.Scene.prototype.remove = function(object) {
     var self = this;
     self.scene.remove(object);
-  };
-
-  VIZI.Scene.prototype.render = function(camera) {
-    var self = this;
-    
-    if (!self.scene) {
-      throw new Error("Scene is required for render");
-    }
-
-    if (!camera) {
-      throw new Error("Camera is required for render");
-    }
-
-    self.renderer.render(self.scene, camera.camera);
-  };
-
-  VIZI.Scene.prototype.resize = function(width, height) {
-    var self = this;
-    self.renderer.setSize(width, height);
   };
 })();

--- a/test/index.html
+++ b/test/index.html
@@ -43,6 +43,7 @@
       <script src="spec/Geo/CRS.js"></script>
       <script src="spec/Geo/CRS.EPSG3857.js"></script>
 
+      <script src="spec/WebGL/Renderer.js"></script>
       <script src="spec/WebGL/Scene.js"></script>
       <script src="spec/WebGL/Camera.js"></script>
       <script src="spec/WebGL/Layer.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -18,6 +18,24 @@
         mocha.reporter("html");
         expect = chai.expect;
         assert = chai.assert;
+
+        // Detect WebGL support by the test runner.
+        // This variable will be used in the spec tests.
+        var ViziTestsWebGLSupported = (function() {
+          try {
+            var canvas = document.createElement("canvas");
+            var ctx = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+            var exts = ctx.getSupportedExtensions();
+            return true;
+          } catch (e) {
+            console.error(e);
+            return false;
+          }
+        })();
+
+        console.log("");
+        console.log("WebGL supported for ViciCities tests:", ViziTestsWebGLSupported);
+        console.log("");
       </script>
 
       <!-- ViziCities source files -->

--- a/test/index.html
+++ b/test/index.html
@@ -21,6 +21,7 @@
 
         // Detect WebGL support by the test runner.
         // This variable will be used in the spec tests.
+        console.log("");
         var ViziTestsWebGLSupported = (function() {
           try {
             var canvas = document.createElement("canvas");
@@ -28,12 +29,10 @@
             var exts = ctx.getSupportedExtensions();
             return true;
           } catch (e) {
-            console.error(e);
+            console.error("Exception in WebGL detection:", e);
             return false;
           }
         })();
-
-        console.log("");
         console.log("WebGL supported for ViciCities tests:", ViziTestsWebGLSupported);
         console.log("");
       </script>

--- a/test/spec/Blueprint/BlueprintHelperTileGrid.js
+++ b/test/spec/Blueprint/BlueprintHelperTileGrid.js
@@ -8,7 +8,7 @@ describe("VIZI.BlueprintHelperTileGrid", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     helper = new VIZI.BlueprintHelperTileGrid(world, {

--- a/test/spec/Blueprint/BlueprintHelperTileGrid.js
+++ b/test/spec/Blueprint/BlueprintHelperTileGrid.js
@@ -8,7 +8,7 @@ describe("VIZI.BlueprintHelperTileGrid", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     helper = new VIZI.BlueprintHelperTileGrid(world, {

--- a/test/spec/Blueprint/BlueprintOutputBuildingTiles.js
+++ b/test/spec/Blueprint/BlueprintOutputBuildingTiles.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputBuildingTiles", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputBuildingTiles.js
+++ b/test/spec/Blueprint/BlueprintOutputBuildingTiles.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputBuildingTiles", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputChoropleth.js
+++ b/test/spec/Blueprint/BlueprintOutputChoropleth.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputChoropleth", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputChoropleth.js
+++ b/test/spec/Blueprint/BlueprintOutputChoropleth.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputChoropleth", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputCollada.js
+++ b/test/spec/Blueprint/BlueprintOutputCollada.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputCollada", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputCollada.js
+++ b/test/spec/Blueprint/BlueprintOutputCollada.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputCollada", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputDebugLines.js
+++ b/test/spec/Blueprint/BlueprintOutputDebugLines.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputDebugLines", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputDebugLines.js
+++ b/test/spec/Blueprint/BlueprintOutputDebugLines.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputDebugLines", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputDebugPoints.js
+++ b/test/spec/Blueprint/BlueprintOutputDebugPoints.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputDebugPoints", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputDebugPoints.js
+++ b/test/spec/Blueprint/BlueprintOutputDebugPoints.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputDebugPoints", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputImageTiles.js
+++ b/test/spec/Blueprint/BlueprintOutputImageTiles.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputImageTiles", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintOutputImageTiles.js
+++ b/test/spec/Blueprint/BlueprintOutputImageTiles.js
@@ -10,7 +10,7 @@ describe("VIZI.BlueprintOutputImageTiles", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintSwitchboard.js
+++ b/test/spec/Blueprint/BlueprintSwitchboard.js
@@ -9,7 +9,7 @@ describe("VIZI.BlueprintSwitchboard", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     config = {

--- a/test/spec/Blueprint/BlueprintSwitchboard.js
+++ b/test/spec/Blueprint/BlueprintSwitchboard.js
@@ -9,7 +9,7 @@ describe("VIZI.BlueprintSwitchboard", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     config = {

--- a/test/spec/Core/World.js
+++ b/test/spec/Core/World.js
@@ -9,7 +9,7 @@ describe("VIZI.World", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
   });
 
@@ -41,7 +41,7 @@ describe("VIZI.World", function() {
       }),
       crs: VIZI.CRS.EPSG900913,
       center: new VIZI.LatLon(50, 1),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
 
     expect(world2.options).to.exist;
@@ -439,13 +439,13 @@ describe("VIZI.World", function() {
   });
 
   it("can render scene", function () {
-    var spy = new sinon.spy(world.scene, "render");
+    var spy = new sinon.spy(world.renderer, "render");
 
     world.render();
 
     expect(spy).to.have.been.called;
 
-    world.scene.render.restore();
+    world.renderer.render.restore();
     spy = undefined;
   });
 
@@ -587,7 +587,7 @@ describe("VIZI.World", function() {
   });
 
   it("can update camera and renderer on window resize", function() {
-    var spy1 = new sinon.spy(world.scene, "resize");
+    var spy1 = new sinon.spy(world.renderer, "resize");
     var spy2 = new sinon.spy(world.camera, "changeAspect");
 
     // Fake window resize dimensions
@@ -599,7 +599,7 @@ describe("VIZI.World", function() {
     expect(spy1).to.have.been.called;
     expect(spy2).to.have.been.called;
 
-    world.scene.resize.restore();
+    world.renderer.resize.restore();
     world.camera.changeAspect.restore();
 
     spy1 = undefined;

--- a/test/spec/Core/World.js
+++ b/test/spec/Core/World.js
@@ -17,13 +17,9 @@ describe("VIZI.World", function() {
     expect(VIZI.World).to.exist;
   });
 
-  // This test cannot be ran without a non-headless renderer.
-  // It will throw but not due to being headless.
-  if (ViziTestsWebGLSupported) {
-    it("throws error when missing viewport element", function() {
-      expect(function() { new VIZI.World(); }).to.throw(Error);
-    });
-  }
+  it("throws error when missing viewport element", function() {
+    expect(function() { new VIZI.World(); }).to.throw(Error);
+  });
 
   it("sets default options when some are missing", function() {
     expect(world.options).to.exist;

--- a/test/spec/Core/World.js
+++ b/test/spec/Core/World.js
@@ -9,7 +9,7 @@ describe("VIZI.World", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
   });
 
@@ -17,9 +17,13 @@ describe("VIZI.World", function() {
     expect(VIZI.World).to.exist;
   });
 
-  it("throws error when missing viewport element", function() {
-    expect(function() { new VIZI.World(); }).to.throw(Error);
-  });
+  // This test cannot be ran without a non-headless renderer.
+  // It will throw but not due to being headless.
+  if (!ViziTestsWebGLSupported) {
+    it("throws error when missing viewport element", function() {
+      expect(function() { new VIZI.World(); }).to.throw(Error);
+    });
+  }
 
   it("sets default options when some are missing", function() {
     expect(world.options).to.exist;
@@ -41,7 +45,7 @@ describe("VIZI.World", function() {
       }),
       crs: VIZI.CRS.EPSG900913,
       center: new VIZI.LatLon(50, 1),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
 
     expect(world2.options).to.exist;

--- a/test/spec/Core/World.js
+++ b/test/spec/Core/World.js
@@ -19,7 +19,7 @@ describe("VIZI.World", function() {
 
   // This test cannot be ran without a non-headless renderer.
   // It will throw but not due to being headless.
-  if (!ViziTestsWebGLSupported) {
+  if (ViziTestsWebGLSupported) {
     it("throws error when missing viewport element", function() {
       expect(function() { new VIZI.World(); }).to.throw(Error);
     });

--- a/test/spec/WebGL/Camera.js
+++ b/test/spec/WebGL/Camera.js
@@ -2,9 +2,7 @@ describe("VIZI.Camera", function() {
   var camera;
 
   before(function() {
-    camera = new VIZI.Camera({
-      aspect: 1024 / 768
-    });
+    camera = new VIZI.Camera();
   });
 
   it("exists in VIZI namespace", function() {
@@ -31,10 +29,6 @@ describe("VIZI.Camera", function() {
     expect(camera.changeAspect).to.exist;
   });
 
-  it("throws error when missing aspect option", function() {
-    expect(function() { new VIZI.Camera(); }).to.throw(Error);
-  });
-
   it("sets default options when some are missing", function() {
     expect(camera.options).to.exist;
     expect(camera.options).to.be.a.object;
@@ -46,36 +40,35 @@ describe("VIZI.Camera", function() {
   });
 
   it("can override default options", function() {
-    var override = new VIZI.Camera({
-      aspect: 1024 / 768,
-      fov: 20,
-      near: 10,
-      far: 800,
-      position: new VIZI.Point(100, 100, 100),
-      target: new VIZI.Point(500, 0, 0)
+    var temp = new VIZI.Camera({
+      aspect   : 1024 / 768,
+      fov      : 20,
+      near     : 10,
+      far      : 800,
+      position : new VIZI.Point(100, 100, 100),
+      target   : new VIZI.Point(500, 0, 0)
     });
 
-    expect(override.options).to.exist;
-    expect(override.options).to.be.a.object;
-    expect(camera.options).to.have.property("fov");
-    expect(camera.options).to.have.property("near");
-    expect(camera.options).to.have.property("far");
-    expect(camera.options).to.have.property("position");
-    expect(camera.options).to.have.property("target");
+    expect(temp.options).to.exist;
+    expect(temp.options).to.be.a.object;
+    expect(temp.options).to.have.property("aspect");
+    expect(temp.options).to.have.property("fov");
+    expect(temp.options).to.have.property("near");
+    expect(temp.options).to.have.property("far");
+    expect(temp.options).to.have.property("position");
+    expect(temp.options).to.have.property("target");
 
-    expect(override.options.fov).to.equal(20);
-    expect(override.options.near).to.equal(10);
-    expect(override.options.far).to.equal(800);
+    expect(temp.options.fov).to.equal(20);
+    expect(temp.options.near).to.equal(10);
+    expect(temp.options.far).to.equal(800);
 
-    expect(override.options.position.x).to.equal(100);
-    expect(override.options.position.y).to.equal(100);
-    expect(override.options.position.z).to.equal(100);
+    expect(temp.options.position.x).to.equal(100);
+    expect(temp.options.position.y).to.equal(100);
+    expect(temp.options.position.z).to.equal(100);
 
-    expect(override.options.target.x).to.equal(500);
-    expect(override.options.target.y).to.equal(0);
-    expect(override.options.target.z).to.equal(0);
-
-    override = undefined;
+    expect(temp.options.target.x).to.equal(500);
+    expect(temp.options.target.y).to.equal(0);
+    expect(temp.options.target.z).to.equal(0);
   });
 
   it("can move to pixel position", function() {

--- a/test/spec/WebGL/Layer.js
+++ b/test/spec/WebGL/Layer.js
@@ -10,7 +10,7 @@ describe("VIZI.Layer", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      renderer : { headless: true }
+      renderer : { headless: !ViziTestsWebGLSupported }
     });
   });
 

--- a/test/spec/WebGL/Layer.js
+++ b/test/spec/WebGL/Layer.js
@@ -10,7 +10,7 @@ describe("VIZI.Layer", function() {
       camera: new VIZI.Camera({
         aspect: 1024 / 768
       }),
-      suppressRenderer: true
+      renderer : { headless: true }
     });
   });
 

--- a/test/spec/WebGL/Renderer.js
+++ b/test/spec/WebGL/Renderer.js
@@ -76,10 +76,12 @@ describe("VIZI.Renderer", function() {
     expect(temp.options.fogColour).to.equal(0x000000);
   });
 
-  it("can create a renderer that is added to the viewport", function() {
-    expect(viewportDOM.children.length).to.equal(1);
-    expect(viewportDOM.firstChild.nodeName).to.equal("CANVAS");
-  });
+  if (ViziTestsWebGLSupported) {
+    it("can create a renderer that is added to the viewport", function() {
+      expect(viewportDOM.children.length).to.equal(1);
+      expect(viewportDOM.firstChild.nodeName).to.equal("CANVAS");
+    });
+  }
 
   it("can render when passed scene and camera", function() {
     var spy = new sinon.spy(renderer, "render");

--- a/test/spec/WebGL/Renderer.js
+++ b/test/spec/WebGL/Renderer.js
@@ -1,0 +1,111 @@
+// TODO: Improve WebGL and DOM testing
+
+describe("VIZI.Renderer", function() {
+  var renderer;
+  var viewportDOM;
+
+  before(function() {
+    viewportDOM = document.createElement("div")
+
+    renderer = new VIZI.Renderer();
+    renderer.init({ viewport : viewportDOM });
+  });
+
+  it("exists in VIZI namespace", function() {
+    expect(VIZI.Renderer).to.exist;
+  });
+  
+  it("has a init method", function() {
+    expect(renderer.init).to.exist;
+  });
+
+  it("has a render method", function() {
+    expect(renderer.render).to.exist;
+  });
+
+  it("has a resize method", function() {
+    expect(renderer.resize).to.exist;
+  });
+
+  it("throws error when init is missing viewport", function() {
+    expect(function() {
+      var temp = new VIZI.Renderer();
+      temp.init({});
+    }).to.throw(Error);
+  });
+
+  it("throws error when rendering without scene", function() {
+    expect(function() {
+      renderer.render(undefined, {});
+    }).to.throw(Error);
+  });
+
+  it("throws error when rendering without camera", function() {
+    expect(function() {
+      renderer.render({}, undefined);
+    }).to.throw(Error);
+  });
+
+  it("sets default options when some are missing", function() {
+    expect(renderer.options).to.exist;
+    expect(renderer.options).to.be.a.object;
+    expect(renderer.options).to.have.property("headless");
+    expect(renderer.options).to.have.property("antialias");
+    expect(renderer.options).to.have.property("fogColour");
+  });
+
+  it("can override default options", function() {
+    var temp = new VIZI.Renderer({
+      headless  : true,
+      antialias : true,
+      fogColour : 0x000000,
+    });
+
+    expect(temp.options).to.exist;
+    expect(temp.options).to.be.a.object;
+    expect(temp.options).to.have.property("headless");
+    expect(temp.options).to.have.property("antialias");
+    expect(temp.options).to.have.property("fogColour");
+
+    expect(temp.options.headless).to.equal(true);
+    expect(temp.options.antialias).to.equal(true);
+    expect(temp.options.fogColour).to.equal(0x000000);
+  });
+
+  it("can create a renderer that is added to the viewport", function() {
+    expect(viewportDOM.children.length).to.equal(1);
+    expect(viewportDOM.firstChild.nodeName).to.equal("CANVAS");
+  });
+
+  it("can render when passed scene and camera", function() {
+    var spy = new sinon.spy(renderer, "render");
+
+    var scene = new VIZI.Scene();
+    var camera = new VIZI.Camera();
+    camera.lookAt(new VIZI.Point());
+    renderer.render(scene, camera);
+
+    expect(spy).to.have.been.called;
+    expect(spy).to.have.been.calledWith(scene, camera);
+
+    renderer.render.restore();
+  });
+
+  // TODO: Disabled until WebGL in Slimer can be solved
+  // it("can update renderer size", function() {
+  //   // Fake window resize dimensions
+  //   var width = 1920;
+  //   var height = 1080;
+
+  //   var oldRendererWidth = renderer.domElement.width;
+  //   var oldRendererHeight = renderer.domElement.height;
+
+  //   renderer.resize(width, height);
+
+  //   var newRendererWidth = renderer.domElement.width;
+  //   var newRendererHeight = renderer.domElement.height;
+
+  //   expect(newRendererWidth).to.not.equal(oldRendererWidth);
+  //   expect(newRendererHeight).to.not.equal(oldRendererHeight);
+  // });
+});

--- a/test/spec/WebGL/Renderer.js
+++ b/test/spec/WebGL/Renderer.js
@@ -29,7 +29,7 @@ describe("VIZI.Renderer", function() {
 
   // This test cannot be ran without a non-headless renderer.
   // It will throw but not due to being headless.
-  if (!ViziTestsWebGLSupported) {
+  if (ViziTestsWebGLSupported) {
     it("throws error when init is missing viewport", function() {
       expect(function() {
         var temp = new VIZI.Renderer();

--- a/test/spec/WebGL/Renderer.js
+++ b/test/spec/WebGL/Renderer.js
@@ -7,7 +7,7 @@ describe("VIZI.Renderer", function() {
   before(function() {
     viewportDOM = document.createElement("div")
 
-    renderer = new VIZI.Renderer();
+    renderer = new VIZI.Renderer({ headless : !ViziTestsWebGLSupported });
     renderer.init({ viewport : viewportDOM });
   });
 
@@ -27,12 +27,16 @@ describe("VIZI.Renderer", function() {
     expect(renderer.resize).to.exist;
   });
 
-  it("throws error when init is missing viewport", function() {
-    expect(function() {
-      var temp = new VIZI.Renderer();
-      temp.init({});
-    }).to.throw(Error);
-  });
+  // This test cannot be ran without a non-headless renderer.
+  // It will throw but not due to being headless.
+  if (!ViziTestsWebGLSupported) {
+    it("throws error when init is missing viewport", function() {
+      expect(function() {
+        var temp = new VIZI.Renderer();
+        temp.init({});
+      }).to.throw(Error);
+    });
+  }
 
   it("throws error when rendering without scene", function() {
     expect(function() {

--- a/test/spec/WebGL/Scene.js
+++ b/test/spec/WebGL/Scene.js
@@ -1,27 +1,18 @@
-// TODO: Improve WebGL and DOM testing
+
 describe("VIZI.Scene", function() {
   var scene;
-  var viewportDOM;
 
   before(function() {
-    viewportDOM = document.createElement("div")
-
-    scene = new VIZI.Scene({
-      viewport: viewportDOM,
-      suppressRenderer: true
-    });
+    scene = new VIZI.Scene();
+    scene.init();
   });
 
   it("exists in VIZI namespace", function() {
     expect(VIZI.Scene).to.exist;
   });
 
-  it("has a createScene method", function() {
-    expect(scene.createScene).to.exist;
-  });
-
-  it("has a createRenderer method", function() {
-    expect(scene.createRenderer).to.exist;
+  it("has a init method", function() {
+    expect(scene.init).to.exist;
   });
 
   it("has an add method", function() {
@@ -32,58 +23,9 @@ describe("VIZI.Scene", function() {
     expect(scene.remove).to.exist;
   });
 
-  it("has a render method", function() {
-    expect(scene.render).to.exist;
-  });
-
-  it("has a resize method", function() {
-    expect(scene.resize).to.exist;
-  });
-
-  it("throws error when missing viewport element", function() {
-    expect(function() { new VIZI.Scene({suppressRenderer: true}); }).to.throw(Error);
-  });
-
-  it("sets default options when some are missing", function() {
-    expect(scene.options).to.exist;
-    expect(scene.options).to.be.a.object;
-    expect(scene.options).to.have.property("antialias");
-    expect(scene.options).to.have.property("fogColour");
-  });
-
-  it("can override default options", function() {
-    var override = new VIZI.Scene({
-      antialias: true,
-      fogColour: 0x000000,
-      viewport: document.createElement("div"),
-      suppressRenderer: true
-    });
-
-    expect(override.options).to.exist;
-    expect(override.options).to.be.a.object;
-    expect(override.options).to.have.property("antialias");
-    expect(override.options).to.have.property("fogColour");
-
-    expect(override.options.antialias).to.equal(true);
-    expect(override.options.fogColour).to.equal(0x000000);
-
-    override = undefined;
-  });
-
   it("has a scene property that contains a THREE.Scene instance", function() {
     expect(scene.scene).to.exist;
     expect(scene.scene).to.be.an.instanceof(THREE.Scene);
-  });
-
-  // TODO: Causes problems with Travis tests
-  // it("has a renderer property that contains a THREE.WebGLRenderer instance", function() {
-  //   expect(scene.renderer).to.exist;
-  //   expect(scene.renderer).to.be.an.instanceof(THREE.WebGLRenderer);
-  // });
-
-  it("can create a renderer and add it to the viewport", function() {
-    expect(viewportDOM.children.length).to.equal(1);
-    expect(viewportDOM.firstChild.nodeName).to.equal("CANVAS");
   });
 
   it("can add object to the scene", function() {
@@ -107,44 +49,4 @@ describe("VIZI.Scene", function() {
 
     expect(scene.scene.children.length).to.equal(prevObjectCount);    
   });
-
-  it("throws an error on render when missing a camera", function() {
-    expect(function() {scene.render();}).to.throw(Error);
-  });
-
-  it("can render when passed a camera", function() {
-    var camera = new VIZI.Camera({
-      aspect: 1024 / 768
-    });
-
-    camera.lookAt(new VIZI.Point());
-
-    var spy = new sinon.spy(scene, "render");
-
-    scene.render(camera);
-
-    expect(spy).to.have.been.called;
-    expect(spy).to.have.been.calledWith(camera);
-
-    scene.render.restore();
-    spy = undefined;
-  });
-
-  // TODO: Disabled until WebGL in Slimer can be solved
-  // it("can update renderer size", function() {
-  //   // Fake window resize dimensions
-  //   var width = 1920;
-  //   var height = 1080;
-
-  //   var oldRendererWidth = scene.renderer.domElement.width;
-  //   var oldRendererHeight = scene.renderer.domElement.height;
-
-  //   scene.resize(width, height);
-
-  //   var newRendererWidth = scene.renderer.domElement.width;
-  //   var newRendererHeight = scene.renderer.domElement.height;
-
-  //   expect(newRendererWidth).to.not.equal(oldRendererWidth);
-  //   expect(newRendererHeight).to.not.equal(oldRendererHeight);
-  // });
 });


### PR DESCRIPTION
* New `VIZI.Renderer`
 * Separated rendering logic from `VIZI.Scene`
 * Allow passing in a custom renderer to `VIZI.World` to gain control over the three.js rendering.
 * Allow headless configuration (previously known as `suppressRenderer`). Making headless code parts cleaner. This is mainly useful for automated tests but can be useful to end users as well.
* `VIZI.Scene`
 * Allow passing in a custom scene to `VIZI.World` to gain control over the three.js scene. This is useful in cases where user wants to override custom materials etc. to eg. building meshes added to the scene.
* General
 * Options map now has "sub-objects" for scene, camera and renderer. Each of them can be a instance of and overriding implementation of `VIZI.Camera` etc. or options object for the default implementation.
 * Updated all tests to the refactoring. Though im not 100% sure what happens with WebGL on travis, I guess we will find out and I'll fix after.
 * Possibility for builds without embedded three.js
 * Examples for how to override renderer, camera and scene with custom implementation
 * `grunt dev` starts a local npm poweder http server for development.
 * `grunt build` is now cleaner and smaller for the minified version. `grunt build_worker` was unified to `build`. Grunt file cleanup.

**Backwards compatibility:** This can break code that uses 0.2.0 branch currently. For me this is a cleaner approach for customization and it will be hard to do without breaking some code out there. Mainly `suppressRenderer` is gone, but I suspect no "production" code is using it. All examples, build steps and tests should function as before.