### PR TITLE
option to omit buildings in BlueprintInputGeoJSON

### DIFF
--- a/src/Blueprint/BlueprintInputGeoJSON.js
+++ b/src/Blueprint/BlueprintInputGeoJSON.js
@@ -92,7 +92,15 @@
           console.warn(error);
           return;
         }
-        
+
+        //filter out unwanted (e.g. manually modeled) buildings
+        if (self.options.omitBuildings) {
+          var omitBuildings = self.options.omitBuildings;
+          data.features = _.reject(data.features, function(feature) {
+            return _.contains(omitBuildings, feature.id);
+          });  
+        }
+          
         self.emit("tileReceived", data, tile);
       });
     });


### PR DESCRIPTION
Allows use of manual models with the map data generated buildings (fixes #80).

For example I'm now doing this to exclude the Helsinki railway station for which we have a manual model in place:

```
var buildingsConfig = {
  input: {
    type: "BlueprintInputGeoJSON",
    options: {
        tilePath: "http://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.json",
        omitBuildings: ["122595198"]
    }
  },
```

May not be the most elegant solution but actually I can't figure out now what would be better.

The data is filtered right after it comes from the OSM / GeoJSON service.

Only thing better I can imagine now would be if the mapzen server could already do the filtering. At least with a quick look it didn't seem to have such feature and it might be out of scope anyways.

Another point is that it might be nice to have a mapping with Vizi from those omitted buildings to the models files to be used instead. So Vizi could put the building models to right places directly itself. But it may well be very application dependent how and why something is omitted so this seems nice and clear in that respect -- how to fill the blank is left to other parts.

I can give the live demo link to where have this running but preferrably a bit later, is such WIP now for other reasons.

Can also add tests & an example if this is wanted.