### PR TITLE
Add option to specify mime type for XML inputs

### DIFF
--- a/src/Blueprint/BlueprintInputGPX.js
+++ b/src/Blueprint/BlueprintInputGPX.js
@@ -48,7 +48,7 @@
     }
 
     // Request data
-    d3.xml(self.options.path, function(error, data) {
+    d3.xml(self.options.path, self.options.mimeType, function(error, data) {
       if (error) {
         if (VIZI.DEBUG) console.log("Failed to request GPX data");
         console.warn(error);

--- a/src/Blueprint/BlueprintInputKML.js
+++ b/src/Blueprint/BlueprintInputKML.js
@@ -49,7 +49,7 @@
     }
 
     // Request data
-    d3.xml(self.options.path, function(error, data) {
+    d3.xml(self.options.path, self.options.mimeType, function(error, data) {
       if (error) {
         if (VIZI.DEBUG) console.log("Failed to request KML data");
         console.warn(error);
@@ -61,7 +61,7 @@
 
       // Process coordinates
       self.processCoordinates(jxon);
-      
+
       self.emit("dataReceived", jxon);
     });
   };


### PR DESCRIPTION
If a web server is not configured properly, it may not serve an XML Content-Type header. If that happens, d3 will not interpret the file as XML, and the data will be `null`. For example, the GitHub pages server does not recognize .gpx files and serves them as "application/octet-stream". This patch offers an option to override the mime type as a fix.