### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Description
+
+Description of the problem. Link to an issue if one exists.
+
+## Solution
+
+A description of what this Pull Request contains in terms of a solution. Include a synopsis of how you achieved this (include any additonal libraries you may have used). If code is reused from elsewhere, reference the GitHub repository line number URL.
+
+## Screenshots
+
+List of screenshots. Use `![image name](image url)` to display an image.
+
+## Known limitations
+
+List any known limitations of this solution.
+
+Any updates should be referenced at the bottom. In the following format `_**Updated: YYYY/MM/DD 00:00**_`


### PR DESCRIPTION
# Description

Lack of PR template makes it a chore to fill out PR content.

# Solution

Utilise GitHub's automated templates to pre-fill PR content.