### PR TITLE
Add polyline support to Web Worker layers

### DIFF
--- a/examples/web-workers-all-the-things/index.html
+++ b/examples/web-workers-all-the-things/index.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Web Workers All The Things ViziCities Example</title>
+  <link rel="stylesheet" href="main.css">
+  <link rel="stylesheet" href="../../dist/vizicities.css">
+</head>
+<body>
+  <div id="world"></div>
+
+  <script src="../vendor/three.min.js"></script>
+  <script src="../vendor/TweenMax.min.js"></script>
+  <script src="../../dist/vizicities.min.js"></script>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/web-workers-all-the-things/main.css
+++ b/examples/web-workers-all-the-things/main.css
@@ -1,0 +1,4 @@
+* { margin: 0; padding: 0; }
+html, body { height: 100%; overflow: hidden;}
+
+#world { height: 100%; }

--- a/examples/web-workers-all-the-things/main.js
+++ b/examples/web-workers-all-the-things/main.js
@@ -1,0 +1,78 @@
+// London
+var coords = [51.505, -0.09];
+
+var world = VIZI.world('world', {
+  skybox: true,
+  postProcessing: true
+}).setView(coords);
+
+// Set position of sun in sky
+world._environment._skybox.setInclination(0.3);
+
+// Add controls
+VIZI.Controls.orbit().addTo(world);
+
+// Leave a single CPU for the main browser thread
+world.createWorkers(7).then(() => {
+  console.log('Workers ready');
+
+  // CartoDB basemap
+  VIZI.imageTileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+  }).addTo(world);
+
+  // Buildings and roads from Mapzen (polygons and linestrings)
+  var topoJSONTileLayer = VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings,roads/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+    workers: true,
+    interactive: false,
+    style: function(feature) {
+      var height;
+
+      if (feature.properties.height) {
+        height = feature.properties.height;
+      } else {
+        height = 10 + Math.random() * 10;
+      }
+
+      return {
+        height: height,
+        lineColor: '#f7c616',
+        lineWidth: 1,
+        lineTransparent: true,
+        lineOpacity: 0.2,
+        lineBlending: THREE.AdditiveBlending,
+        lineRenderOrder: 2
+      };
+    },
+    filter: function(feature) {
+      // Don't show points
+      return feature.geometry.type !== 'Point';
+    },
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://whosonfirst.mapzen.com#License">Who\'s On First</a>.'
+  }).addTo(world);
+
+  // London Underground lines
+  VIZI.geoJSONWorkerLayer('https://rawgit.com/robhawkes/4acb9d6a6a5f00a377e2/raw/30ae704a44e10f2e13fb7e956e80c3b22e8e7e81/tfl_lines.json', {
+    output: true,
+    interactive: true,
+    style: function(feature) {
+      var colour = feature.properties.lines[0].colour || '#ffffff';
+
+      return {
+        lineColor: colour,
+        lineHeight: 20,
+        lineWidth: 3,
+        lineTransparent: true,
+        lineOpacity: 0.5,
+        lineBlending: THREE.AdditiveBlending,
+        lineRenderOrder: 2
+      };
+    },
+    // onEachFeature: function(feature, layer) {
+    //   layer.on('click', function(layer, point2d, point3d, intersects) {
+    //     console.log(layer, point2d, point3d, intersects);
+    //   });
+    // },
+    attribution: '&copy; Transport for London.'
+  }).addTo(world);
+});

--- a/examples/web-workers-all-the-things/vizicities-worker.js
+++ b/examples/web-workers-all-the-things/vizicities-worker.js
@@ -1,0 +1,61 @@
+importScripts('../vendor/three.min.js');
+
+// Special version of ViziCities without controls (no DOM errors)
+importScripts('../../dist/vizicities-worker.min.js');
+
+const DEBUG = false;
+
+if (DEBUG) { console.log('Worker started', performance.now()); }
+
+// Send startup message to main thread
+postMessage({
+  type: 'startup',
+  payload: performance.now()
+});
+
+// Recieve message from main thread
+onmessage = (event) => {
+  if (!event.data.method) {
+    postMessage({
+      type: 'error',
+      payload: 'No method provided'
+    });
+
+    return;
+  }
+
+  var time = performance.now();
+  if (DEBUG) { console.log('Message received from main thread', time, event.data); }
+  // if (DEBUG) console.log('Time to receive message', time - event.data);
+
+  // Run method
+  // if (!methods[event.data.method]) {
+  //   postMessage({
+  //     type: 'error',
+  //     payload: 'Method not found'
+  //   });
+
+  //   return;
+  // }
+
+  var methods = event.data.method.split('.');
+
+  var _method = VIZI[methods[0]];
+
+  if (methods.length > 1) {
+    for (var i = 1; i < methods.length; i++) {
+      _method = _method[methods[i]];
+    }
+  }
+
+  // Call method with given arguments
+  _method.apply(this, event.data.args).then((result) => {
+    console.log('Message sent from worker', performance.now());
+
+    // Return results
+    postMessage({
+      type: 'result',
+      payload: result.data
+    }, result.transferrables);
+  });
+};

--- a/src/layer/GeoJSONLayer.js
+++ b/src/layer/GeoJSONLayer.js
@@ -219,7 +219,7 @@ class GeoJSONLayer extends LayerGroup {
             this.add(this._polygonMesh);
 
             if (result.pickingMesh) {
-              this._pickingMesh.add(pickingMesh);
+              this._pickingMesh.add(result.pickingMesh);
             }
           });
         }
@@ -231,7 +231,7 @@ class GeoJSONLayer extends LayerGroup {
             this.add(this._polylineMesh);
 
             if (result.pickingMesh) {
-              this._pickingMesh.add(pickingMesh);
+              this._pickingMesh.add(result.pickingMesh);
             }
           });
         }
@@ -273,72 +273,6 @@ class GeoJSONLayer extends LayerGroup {
     style = extend({}, GeoJSON.defaultStyle, style);
 
     return PolylineLayer.SetMesh(attributes, attributeLengths, flat, style, this._options);
-
-    // var geometry = new THREE.BufferGeometry();
-
-    // // itemSize = 3 because there are 3 values (components) per vertex
-    // geometry.addAttribute('position', new THREE.BufferAttribute(attributes.vertices, 3));
-
-    // if (attributes.normals) {
-    //   geometry.addAttribute('normal', new THREE.BufferAttribute(attributes.normals, 3));
-    // }
-
-    // geometry.addAttribute('color', new THREE.BufferAttribute(attributes.colours, 3));
-
-    // if (attributes.pickingIds) {
-    //   geometry.addAttribute('pickingId', new THREE.BufferAttribute(attributes.pickingIds, 1));
-    // }
-
-    // geometry.computeBoundingBox();
-
-    // // TODO: Make this work when style is a function per feature
-    // var style = (typeof this._options.style === 'function') ? this._options.style(this._geojson.features[0]) : this._options.style;
-    // style = extend({}, GeoJSON.defaultStyle, style);
-
-    // var material;
-    // if (this._options.polylineMaterial && this._options.polylineMaterial instanceof THREE.Material) {
-    //   material = this._options.polylineMaterial;
-    // } else {
-    //   material = new THREE.LineBasicMaterial({
-    //     vertexColors: THREE.VertexColors,
-    //     linewidth: style.lineWidth,
-    //     transparent: style.lineTransparent,
-    //     opacity: style.lineOpacity,
-    //     blending: style.lineBlending
-    //   });
-    // }
-
-    // var mesh;
-
-    // // Pass mesh through callback, if defined
-    // if (typeof this._options.onPolylineMesh === 'function') {
-    //   mesh = this._options.onPolylineMesh(geometry, material);
-    // } else {
-    //   mesh = new THREE.LineSegments(geometry, material);
-
-    //   if (style.lineRenderOrder !== undefined) {
-    //     material.depthWrite = false;
-    //     mesh.renderOrder = style.lineRenderOrder;
-    //   }
-
-    //   mesh.castShadow = true;
-    //   // mesh.receiveShadow = true;
-    // }
-
-    // // TODO: Allow this to be overridden, or copy mesh instead of creating a new
-    // // one just for picking
-    // if (this._options.interactive && this._pickingMesh) {
-    //   material = new PickingMaterial();
-    //   // material.side = THREE.BackSide;
-
-    //   // Make the line wider / easier to pick
-    //   material.linewidth = style.lineWidth + material.linePadding;
-
-    //   var pickingMesh = new THREE.LineSegments(geometry, material);
-    //   this._pickingMesh.add(pickingMesh);
-    // }
-
-    // this._polylineMesh = mesh;
   }
 
   _setPointMesh(attributes) {

--- a/src/layer/GeoJSONLayer.js
+++ b/src/layer/GeoJSONLayer.js
@@ -178,6 +178,12 @@ class GeoJSONLayer extends LayerGroup {
         var polygonFlat = true;
 
         var polylineAttributes = [];
+        var polylineAttributeLengths = {
+          positions: 3,
+          colors: 3
+        };
+        var polylineFlat = true;
+
         var pointAttributes = [];
 
         this._layers.forEach(layer => {
@@ -193,6 +199,14 @@ class GeoJSONLayer extends LayerGroup {
             }
           } else if (layer instanceof PolylineLayer) {
             polylineAttributes.push(layer.getBufferAttributes());
+
+            if (polylineFlat && !layer.isFlat()) {
+              polylineFlat = false;
+            }
+
+            if (this._options.interactive) {
+              polylineAttributeLengths.pickingIds = 1;
+            }
           } else if (layer instanceof PointLayer) {
             pointAttributes.push(layer.getBufferAttributes());
           }
@@ -212,8 +226,14 @@ class GeoJSONLayer extends LayerGroup {
 
         if (polylineAttributes.length > 0) {
           var mergedPolylineAttributes = Buffer.mergeAttributes(polylineAttributes);
-          this._setPolylineMesh(mergedPolylineAttributes);
-          this.add(this._polylineMesh);
+          this._setPolylineMesh(mergedPolylineAttributes, polylineAttributeLengths, polylineFlat).then((result) => {
+            this._polylineMesh = result.mesh;
+            this.add(this._polylineMesh);
+
+            if (result.pickingMesh) {
+              this._pickingMesh.add(pickingMesh);
+            }
+          });
         }
 
         if (pointAttributes.length > 0) {
@@ -247,72 +267,78 @@ class GeoJSONLayer extends LayerGroup {
     return PolygonLayer.SetMesh(attributes, attributeLengths, flat, style, this._options, this._world._environment._skybox);
   }
 
-  _setPolylineMesh(attributes) {
-    var geometry = new THREE.BufferGeometry();
-
-    // itemSize = 3 because there are 3 values (components) per vertex
-    geometry.addAttribute('position', new THREE.BufferAttribute(attributes.vertices, 3));
-
-    if (attributes.normals) {
-      geometry.addAttribute('normal', new THREE.BufferAttribute(attributes.normals, 3));
-    }
-
-    geometry.addAttribute('color', new THREE.BufferAttribute(attributes.colours, 3));
-
-    if (attributes.pickingIds) {
-      geometry.addAttribute('pickingId', new THREE.BufferAttribute(attributes.pickingIds, 1));
-    }
-
-    geometry.computeBoundingBox();
-
+  _setPolylineMesh(attributes, attributeLengths, flat) {
     // TODO: Make this work when style is a function per feature
     var style = (typeof this._options.style === 'function') ? this._options.style(this._geojson.features[0]) : this._options.style;
     style = extend({}, GeoJSON.defaultStyle, style);
 
-    var material;
-    if (this._options.polylineMaterial && this._options.polylineMaterial instanceof THREE.Material) {
-      material = this._options.polylineMaterial;
-    } else {
-      material = new THREE.LineBasicMaterial({
-        vertexColors: THREE.VertexColors,
-        linewidth: style.lineWidth,
-        transparent: style.lineTransparent,
-        opacity: style.lineOpacity,
-        blending: style.lineBlending
-      });
-    }
+    return PolylineLayer.SetMesh(attributes, attributeLengths, flat, style, this._options);
 
-    var mesh;
+    // var geometry = new THREE.BufferGeometry();
 
-    // Pass mesh through callback, if defined
-    if (typeof this._options.onPolylineMesh === 'function') {
-      mesh = this._options.onPolylineMesh(geometry, material);
-    } else {
-      mesh = new THREE.LineSegments(geometry, material);
+    // // itemSize = 3 because there are 3 values (components) per vertex
+    // geometry.addAttribute('position', new THREE.BufferAttribute(attributes.vertices, 3));
 
-      if (style.lineRenderOrder !== undefined) {
-        material.depthWrite = false;
-        mesh.renderOrder = style.lineRenderOrder;
-      }
+    // if (attributes.normals) {
+    //   geometry.addAttribute('normal', new THREE.BufferAttribute(attributes.normals, 3));
+    // }
 
-      mesh.castShadow = true;
-      // mesh.receiveShadow = true;
-    }
+    // geometry.addAttribute('color', new THREE.BufferAttribute(attributes.colours, 3));
 
-    // TODO: Allow this to be overridden, or copy mesh instead of creating a new
-    // one just for picking
-    if (this._options.interactive && this._pickingMesh) {
-      material = new PickingMaterial();
-      // material.side = THREE.BackSide;
+    // if (attributes.pickingIds) {
+    //   geometry.addAttribute('pickingId', new THREE.BufferAttribute(attributes.pickingIds, 1));
+    // }
 
-      // Make the line wider / easier to pick
-      material.linewidth = style.lineWidth + material.linePadding;
+    // geometry.computeBoundingBox();
 
-      var pickingMesh = new THREE.LineSegments(geometry, material);
-      this._pickingMesh.add(pickingMesh);
-    }
+    // // TODO: Make this work when style is a function per feature
+    // var style = (typeof this._options.style === 'function') ? this._options.style(this._geojson.features[0]) : this._options.style;
+    // style = extend({}, GeoJSON.defaultStyle, style);
 
-    this._polylineMesh = mesh;
+    // var material;
+    // if (this._options.polylineMaterial && this._options.polylineMaterial instanceof THREE.Material) {
+    //   material = this._options.polylineMaterial;
+    // } else {
+    //   material = new THREE.LineBasicMaterial({
+    //     vertexColors: THREE.VertexColors,
+    //     linewidth: style.lineWidth,
+    //     transparent: style.lineTransparent,
+    //     opacity: style.lineOpacity,
+    //     blending: style.lineBlending
+    //   });
+    // }
+
+    // var mesh;
+
+    // // Pass mesh through callback, if defined
+    // if (typeof this._options.onPolylineMesh === 'function') {
+    //   mesh = this._options.onPolylineMesh(geometry, material);
+    // } else {
+    //   mesh = new THREE.LineSegments(geometry, material);
+
+    //   if (style.lineRenderOrder !== undefined) {
+    //     material.depthWrite = false;
+    //     mesh.renderOrder = style.lineRenderOrder;
+    //   }
+
+    //   mesh.castShadow = true;
+    //   // mesh.receiveShadow = true;
+    // }
+
+    // // TODO: Allow this to be overridden, or copy mesh instead of creating a new
+    // // one just for picking
+    // if (this._options.interactive && this._pickingMesh) {
+    //   material = new PickingMaterial();
+    //   // material.side = THREE.BackSide;
+
+    //   // Make the line wider / easier to pick
+    //   material.linewidth = style.lineWidth + material.linePadding;
+
+    //   var pickingMesh = new THREE.LineSegments(geometry, material);
+    //   this._pickingMesh.add(pickingMesh);
+    // }
+
+    // this._polylineMesh = mesh;
   }
 
   _setPointMesh(attributes) {

--- a/src/layer/GeoJSONWorkerLayer.js
+++ b/src/layer/GeoJSONWorkerLayer.js
@@ -212,7 +212,7 @@ class GeoJSONWorkerLayer extends Layer {
         this.add(this._polygonMesh);
 
         if (result.pickingMesh) {
-          this._pickingMesh.add(pickingMesh);
+          this._pickingMesh.add(result.pickingMesh);
         }
       });
     }
@@ -316,7 +316,7 @@ class GeoJSONWorkerLayer extends Layer {
         this.add(this._polylineMesh);
 
         if (result.pickingMesh) {
-          this._pickingMesh.add(pickingMesh);
+          this._pickingMesh.add(result.pickingMesh);
         }
       });
     }

--- a/src/layer/geometry/PolygonLayer.js
+++ b/src/layer/geometry/PolygonLayer.js
@@ -33,8 +33,8 @@ class PolygonLayer extends Layer {
       // Custom material override
       //
       // TODO: Should this be in the style object?
-      material: null,
-      onMesh: null,
+      polygonMaterial: null,
+      onPolygonMesh: null,
       onBufferAttributes: null,
       // This default style is separate to Util.GeoJSON.defaultStyle
       style: {

--- a/src/layer/geometry/PolygonLayer.js
+++ b/src/layer/geometry/PolygonLayer.js
@@ -97,7 +97,7 @@ class PolygonLayer extends Layer {
             this.add(result.mesh);
 
             if (result.pickingMesh) {
-              this._pickingMesh.add(pickingMesh);
+              this._pickingMesh.add(result.pickingMesh);
             }
           });
         }
@@ -379,7 +379,7 @@ class PolygonLayer extends Layer {
             this._offset.x = -1 * point.x;
             this._offset.y = -1 * point.y;
 
-            this._pointScale = this._world.pointScale(latlon);
+            this._options.pointScale = this._world.pointScale(latlon);
           }
 
           return point;

--- a/src/layer/geometry/PolylineLayer.js
+++ b/src/layer/geometry/PolylineLayer.js
@@ -32,8 +32,8 @@ class PolylineLayer extends Layer {
       // Custom material override
       //
       // TODO: Should this be in the style object?
-      material: null,
-      onMesh: null,
+      polylineMaterial: null,
+      onPolylineMesh: null,
       onBufferAttributes: null,
       // This default style is separate to Util.GeoJSON.defaultStyle
       style: {
@@ -59,34 +59,57 @@ class PolylineLayer extends Layer {
   }
 
   _onAdd(world) {
-    this._setCoordinates();
+    return new Promise((resolve, reject) => {
+      this._setCoordinates();
 
-    if (this._options.interactive) {
-      // Only add to picking mesh if this layer is controlling output
-      //
-      // Otherwise, assume another component will eventually add a mesh to
-      // the picking scene
-      if (this.isOutput()) {
-        this._pickingMesh = new THREE.Object3D();
-        this.addToPicking(this._pickingMesh);
+      if (this._options.interactive) {
+        // Only add to picking mesh if this layer is controlling output
+        //
+        // Otherwise, assume another component will eventually add a mesh to
+        // the picking scene
+        if (this.isOutput()) {
+          this._pickingMesh = new THREE.Object3D();
+          this.addToPicking(this._pickingMesh);
+        }
+
+        this._setPickingId();
+        this._addPickingEvents();
       }
 
-      this._setPickingId();
-      this._addPickingEvents();
-    }
+      // Store geometry representation as instances of THREE.BufferAttribute
+      PolylineLayer.SetBufferAttributes(this._projectedCoordinates, this._options).then((result) => {
+        this._bufferAttributes = Buffer.mergeAttributes(result.attributes);
+        this._flat = result.flat;
 
-    // Store geometry representation as instances of THREE.BufferAttribute
-    this._setBufferAttributes();
+        var attributeLengths = {
+          positions: 3,
+          colors: 3
+        };
 
-    if (this.isOutput()) {
-      // Set mesh if not merging elsewhere
-      this._setMesh(this._bufferAttributes);
+        if (this._options.interactive) {
+          attributeLengths.pickingIds = 1;
+        }
 
-      // Output mesh
-      this.add(this._mesh);
-    }
+        if (this.isOutput()) {
+          var style = this._options.style;
 
-    return Promise.resolve(this);
+          // Set mesh if not merging elsewhere
+          PolylineLayer.SetMesh(this._bufferAttributes, attributeLengths, this._flat, style, this._options).then((result) => {
+            // Output mesh
+            this.add(result.mesh);
+
+            if (result.pickingMesh) {
+              this._pickingMesh.add(pickingMesh);
+            }
+          });
+        }
+
+        result.attributes = null;
+        result = null;
+
+        resolve(this);
+      });
+    });
   }
 
   // Return center of polyline as a LatLon
@@ -118,28 +141,22 @@ class PolylineLayer extends Layer {
     });
   }
 
-  // Create and store reference to THREE.BufferAttribute data for this layer
-  _setBufferAttributes() {
-    var attributes;
-
-    // Only use this if you know what you're doing
-    if (typeof this._options.onBufferAttributes === 'function') {
-      // TODO: Probably want to pass something less general as arguments,
-      // though passing the instance will do for now (it's everything)
-      attributes = this._options.onBufferAttributes(this);
-    } else {
+  static SetBufferAttributes(coordinates, options) {
+    return new Promise((resolve) => {
       var height = 0;
 
       // Convert height into world units
-      if (this._options.style.lineHeight) {
-        height = this._world.metresToWorld(this._options.style.lineHeight, this._pointScale);
+      if (options.style.lineHeight) {
+        height = Geo.world.metresToWorld(options.style.lineHeight, options.pointScale);
       }
 
       var colour = new THREE.Color();
-      colour.set(this._options.style.lineColor);
+      colour.set(options.style.lineColor);
+
+      var flat = true;
 
       // For each line
-      attributes = this._projectedCoordinates.map(_projectedCoordinates => {
+      var attributes = coordinates.map(_projectedCoordinates => {
         var _vertices = [];
         var _colours = [];
 
@@ -164,20 +181,20 @@ class PolylineLayer extends Layer {
           verticesCount: _vertices.length
         };
 
-        if (this._options.interactive && this._pickingId) {
+        if (options.interactive && options.pickingId) {
           // Inject picking ID
-          line.pickingId = this._pickingId;
+          line.pickingId = options.pickingId;
         }
 
         // Convert line representation to proper attribute arrays
-        return this._toAttributes(line);
+        return PolylineLayer.ToAttributes(line);
       });
-    }
 
-    this._bufferAttributes = Buffer.mergeAttributes(attributes);
-
-    // Original attributes are no longer required so free the memory
-    attributes = null;
+      resolve({
+        attributes: attributes,
+        flat: flat
+      });
+    });
   }
 
   getBufferAttributes() {
@@ -203,32 +220,18 @@ class PolylineLayer extends Layer {
     this._projectedCoordinates = null;
   }
 
-  // Create and store mesh from buffer attributes
-  //
-  // This is only called if the layer is controlling its own output
-  _setMesh(attributes) {
+  static SetMesh(attributes, attributeLengths, flat, style, options) {
     var geometry = new THREE.BufferGeometry();
 
-    // itemSize = 3 because there are 3 values (components) per vertex
-    geometry.addAttribute('position', new THREE.BufferAttribute(attributes.vertices, 3));
-
-    if (attributes.normals) {
-      geometry.addAttribute('normal', new THREE.BufferAttribute(attributes.normals, 3));
-    }
-
-    geometry.addAttribute('color', new THREE.BufferAttribute(attributes.colours, 3));
-
-    if (attributes.pickingIds) {
-      geometry.addAttribute('pickingId', new THREE.BufferAttribute(attributes.pickingIds, 1));
+    for (var key in attributes) {
+      geometry.addAttribute(key.slice(0, -1), new THREE.BufferAttribute(attributes[key], attributeLengths[key]));
     }
 
     geometry.computeBoundingBox();
 
-    var style = this._options.style;
     var material;
-
-    if (this._options.material && this._options.material instanceof THREE.Material) {
-      material = this._options.material;
+    if (options.polylineMaterial && options.polylineMaterial instanceof THREE.Material) {
+      material = options.polylineMaterial;
     } else {
       material = new THREE.LineBasicMaterial({
         vertexColors: THREE.VertexColors,
@@ -242,8 +245,8 @@ class PolylineLayer extends Layer {
     var mesh;
 
     // Pass mesh through callback, if defined
-    if (typeof this._options.onMesh === 'function') {
-      mesh = this._options.onMesh(geometry, material);
+    if (typeof options.onPolylineMesh === 'function') {
+      mesh = options.onPolylineMesh(geometry, material);
     } else {
       mesh = new THREE.LineSegments(geometry, material);
 
@@ -256,9 +259,7 @@ class PolylineLayer extends Layer {
       // mesh.receiveShadow = true;
     }
 
-    // TODO: Allow this to be overridden, or copy mesh instead of creating a new
-    // one just for picking
-    if (this._options.interactive && this._pickingMesh) {
+    if (options.interactive) {
       material = new PickingMaterial();
       // material.side = THREE.BackSide;
 
@@ -266,10 +267,12 @@ class PolylineLayer extends Layer {
       material.linewidth = style.lineWidth + material.linePadding;
 
       var pickingMesh = new THREE.LineSegments(geometry, material);
-      this._pickingMesh.add(pickingMesh);
     }
 
-    this._mesh = mesh;
+    return Promise.resolve({
+      mesh: mesh,
+      pickingMesh: pickingMesh
+    });
   }
 
   // Convert and project coordinates
@@ -323,11 +326,7 @@ class PolylineLayer extends Layer {
     });
   }
 
-  // Transform line representation into attribute arrays that can be used by
-  // THREE.BufferGeometry
-  //
-  // TODO: Can this be simplified? It's messy and huge
-  _toAttributes(line) {
+  static ToAttributes(line) {
     // Three components per vertex
     var vertices = new Float32Array(line.verticesCount * 3);
     var colours = new Float32Array(line.verticesCount * 3);
@@ -341,13 +340,6 @@ class PolylineLayer extends Layer {
     var _vertices = line.vertices;
     var _colour = line.colours;
 
-    var normals;
-    var _normals;
-    if (line.normals) {
-      normals = new Float32Array(line.verticesCount * 3);
-      _normals = line.normals;
-    }
-
     var _pickingId;
     if (pickingIds) {
       _pickingId = line.pickingId;
@@ -360,26 +352,11 @@ class PolylineLayer extends Layer {
       var ay = _vertices[i][1];
       var az = _vertices[i][2];
 
-      var nx;
-      var ny;
-      var nz;
-      if (_normals) {
-        nx = _normals[i][0];
-        ny = _normals[i][1];
-        nz = _normals[i][2];
-      }
-
       var c1 = _colour[i];
 
       vertices[lastIndex * 3 + 0] = ax;
       vertices[lastIndex * 3 + 1] = ay;
       vertices[lastIndex * 3 + 2] = az;
-
-      if (normals) {
-        normals[lastIndex * 3 + 0] = nx;
-        normals[lastIndex * 3 + 1] = ny;
-        normals[lastIndex * 3 + 2] = nz;
-      }
 
       colours[lastIndex * 3 + 0] = c1[0];
       colours[lastIndex * 3 + 1] = c1[1];
@@ -393,13 +370,9 @@ class PolylineLayer extends Layer {
     }
 
     var attributes = {
-      vertices: vertices,
-      colours: colours
+      positions: vertices,
+      colors: colours
     };
-
-    if (normals) {
-      attributes.normals = normals;
-    }
 
     if (pickingIds) {
       attributes.pickingIds = pickingIds;

--- a/src/layer/geometry/PolylineLayer.js
+++ b/src/layer/geometry/PolylineLayer.js
@@ -19,6 +19,7 @@
 import Layer from '../Layer';
 import extend from 'lodash.assign';
 import THREE from 'three';
+import Geo from '../../geo/Geo';
 import {latLon as LatLon} from '../../geo/LatLon';
 import {point as Point} from '../../geo/Point';
 import PickingMaterial from '../../engine/PickingMaterial';
@@ -99,7 +100,7 @@ class PolylineLayer extends Layer {
             this.add(result.mesh);
 
             if (result.pickingMesh) {
-              this._pickingMesh.add(pickingMesh);
+              this._pickingMesh.add(result.pickingMesh);
             }
           });
         }
@@ -147,7 +148,7 @@ class PolylineLayer extends Layer {
 
       // Convert height into world units
       if (options.style.lineHeight) {
-        height = Geo.world.metresToWorld(options.style.lineHeight, options.pointScale);
+        height = Geo.metresToWorld(options.style.lineHeight, options.pointScale);
       }
 
       var colour = new THREE.Color();
@@ -318,7 +319,7 @@ class PolylineLayer extends Layer {
           this._offset.x = -1 * point.x;
           this._offset.y = -1 * point.y;
 
-          this._pointScale = this._world.pointScale(latlon);
+          this._options.pointScale = this._world.pointScale(latlon);
         }
 
         return point;


### PR DESCRIPTION
# Description

The current implementation of Web Worker layers within ViziCities only supports polygon geometry. Polyline geometry is required for 100% coverage of GeoJSON.

# Solution

This PR adds polyline support for Web Worker layers as well as generally tidying up polyline logic across the board.