### PR TITLE
Add support for points in Web Worker layers

### DIFF
--- a/src/layer/GeoJSONLayer.js
+++ b/src/layer/GeoJSONLayer.js
@@ -351,7 +351,7 @@ class GeoJSONLayer extends LayerGroup {
     if (geometry.type === 'Point' || geometry.type === 'MultiPoint') {
       // Get geometry object to use for point, if provided
       if (typeof this._options.pointGeometry === 'function') {
-        options.geometry = this._options.pointGeometry(feature);
+        options.pointGeometry = this._options.pointGeometry(feature);
       }
 
       // Get material instance to use for point, if provided

--- a/src/layer/GeoJSONWorkerLayer.js
+++ b/src/layer/GeoJSONWorkerLayer.js
@@ -7,6 +7,7 @@ import Buffer from '../util/Buffer';
 import Stringify from '../util/Stringify';
 import PolygonLayer from './geometry/PolygonLayer';
 import PolylineLayer from './geometry/PolylineLayer';
+import PointLayer from './geometry/PointLayer';
 import {latLon as LatLon} from '../geo/LatLon';
 import {point as Point} from '../geo/Point';
 import Geo from '../geo/Geo';
@@ -104,6 +105,10 @@ class GeoJSONWorkerLayer extends Layer {
 
         if (results.polylines) {
           this._processPolylineResults(results.polylines);
+        }
+
+        if (results.points) {
+          this._processPointResults(results.points);
         }
 
         resolve();
@@ -322,6 +327,112 @@ class GeoJSONWorkerLayer extends Layer {
     }
   }
 
+  _processPointResults(results) {
+    var splitPositions = Buffer.splitFloat32Array(results.attributes.positions);
+    var splitNormals = Buffer.splitFloat32Array(results.attributes.normals);
+    var splitColors = Buffer.splitFloat32Array(results.attributes.colors);
+
+    var splitProperties;
+    if (results.properties) {
+      splitProperties = Buffer.splitUint8Array(results.properties);
+    }
+
+    var flats = results.flats;
+
+    var objects = [];
+    var obj;
+    var pickingId;
+    var pickingIds;
+    var properties;
+
+    var pointAttributeLengths = {
+      positions: 3,
+      normals: 3,
+      colors: 3
+    };
+
+    for (var i = 0; i < splitPositions.length; i++) {
+      if (splitProperties && splitProperties[i]) {
+        properties = JSON.parse(Buffer.uint8ArrayToString(splitProperties[i]));
+      } else {
+        properties = {};
+      }
+
+      // WORKERS: obj.attributes should actually an array of polygons for
+      // the feature, though the current logic isn't aware of that
+      obj = {
+        attributes: [{
+          positions: splitPositions[i],
+          normals: splitNormals[i],
+          colors: splitColors[i]
+        }],
+        properties: properties,
+        flat: flats[i]
+      };
+
+      // WORKERS: If interactive, generate unique ID for each feature, create
+      // the buffer attributes and set up event listeners
+      if (this._options.interactive) {
+        pickingId = this.getPickingId();
+
+        pickingIds = new Float32Array(splitPositions[i].length / 3);
+        pickingIds.fill(pickingId);
+
+        obj.attributes[0].pickingIds = pickingIds;
+
+        pointAttributeLengths.pickingIds = 1;
+
+        this._addPicking(pickingId, properties);
+      }
+
+      // TODO: Make this specific to polygon attributes
+      if (typeof this._options.onAddAttributes === 'function') {
+        var customAttributes = this._options.onAddAttributes(obj.attributes[0], properties);
+        var customAttribute;
+        for (var key in customAttributes) {
+          customAttribute = customAttributes[key];
+          obj.attributes[0][key] = customAttribute.value;
+          pointAttributeLengths[key] = customAttribute.length;
+        }
+      }
+
+      objects.push(obj);
+    }
+
+    var pointAttributes = [];
+
+    var pointFlat = true;
+
+    var obj;
+    for (var i = 0; i < objects.length; i++) {
+      obj = objects[i];
+
+      if (pointFlat && !obj.flat) {
+        pointFlat = false;
+      }
+
+      var bufferAttributes = Buffer.mergeAttributes(obj.attributes);
+      pointAttributes.push(bufferAttributes);
+    };
+
+    if (pointAttributes.length > 0) {
+      var mergedPointAttributes = Buffer.mergeAttributes(pointAttributes);
+
+      // TODO: Make this work when style is a function per feature
+      var style = (typeof this._options.style === 'function') ? this._options.style(objects[0]) : this._options.style;
+      style = extend({}, GeoJSON.defaultStyle, style);
+
+      this._setPointMesh(mergedPointAttributes, pointAttributeLengths, style, pointFlat).then((result) => {
+        this._pointMesh = result.mesh;
+        this.add(this._pointMesh);
+
+        if (result.pickingMesh) {
+          this._pickingMesh.add(result.pickingMesh);
+        }
+      });
+    }
+  }
+
   // TODO: At some point this needs to return all the features to the main thread
   // so it can generate meshes and output to the scene, as well as perhaps creating
   // individual layers / components for each feature to track things like picking
@@ -329,6 +440,8 @@ class GeoJSONWorkerLayer extends Layer {
   //
   // TODO: Find a way so the origin point isn't needed to be passed in as it
   // feels a bit messy and against the idea of a static Geo class
+  //
+  // TODO: Support passing custom geometry for point layers
   static Process(geojson, topojson, headers, originPoint, _style, _properties) {
     return new Promise((resolve, reject) => {
       GeoJSONWorkerLayer.ProcessGeoJSON(geojson, headers).then((res) => {
@@ -346,6 +459,7 @@ class GeoJSONWorkerLayer extends Layer {
         var pointScale;
         var polygons = [];
         var polylines = [];
+        var points = [];
 
         // Deserialise style function if provided
         if (typeof _style === 'string') {
@@ -450,11 +564,43 @@ class GeoJSONWorkerLayer extends Layer {
             polylines.push(polyline);
           }
 
-          if (geometry.type === 'Point' || geometry.type === 'MultiPoint') {}
+          if (geometry.type === 'Point' || geometry.type === 'MultiPoint') {
+            coordinates = (PointLayer.isSingle(coordinates)) ? [coordinates] : coordinates;
+
+            var converted = coordinates.map(coordinate => {
+              return LatLon(coordinate[1], coordinate[0]);
+            });
+
+            var point;
+            var projected = converted.map((latlon) => {
+              point = Geo.latLonToPoint(latlon)._subtract(originPoint);
+
+              if (!pointScale) {
+                pointScale = Geo.pointScale(latlon);
+              }
+
+              return point;
+            });
+
+            var point = {
+              projected: projected,
+              options: {
+                pointScale: pointScale,
+                style: style
+              }
+            };
+
+            if (_properties) {
+              point.properties = feature.properties;
+            }
+
+            points.push(point);
+          }
         };
 
         var polygonBufferPromises = [];
         var polylineBufferPromises = [];
+        var pointBufferPromises = [];
 
         var polygon;
         for (var i = 0; i < polygons.length; i++) {
@@ -466,6 +612,12 @@ class GeoJSONWorkerLayer extends Layer {
         for (var i = 0; i < polylines.length; i++) {
           polyline = polylines[i];
           polylineBufferPromises.push(PolylineLayer.SetBufferAttributes(polyline.projected, polyline.options));
+        };
+
+        var point;
+        for (var i = 0; i < points.length; i++) {
+          point = points[i];
+          pointBufferPromises.push(PointLayer.SetBufferAttributes(point.projected, point.options));
         };
 
         var data = {};
@@ -481,9 +633,14 @@ class GeoJSONWorkerLayer extends Layer {
             data.polylines = result.data;
             transferrables = transferrables.concat(result.transferrables);
 
-            resolve({
-              data: data,
-              transferrables: transferrables
+            GeoJSONWorkerLayer.ProcessPoints(pointBufferPromises, points, _properties).then((result) => {
+              data.points = result.data;
+              transferrables = transferrables.concat(result.transferrables);
+
+              resolve({
+                data: data,
+                transferrables: transferrables
+              });
             });
           });
         });
@@ -655,6 +812,92 @@ class GeoJSONWorkerLayer extends Layer {
     });
   }
 
+  // TODO: Dedupe with ProcessPolygons as they are identical
+  static ProcessPoints(pointPromises, points, _properties) {
+    return new Promise((resolve, reject) => {
+      Promise.all(pointPromises).then((results) => {
+        var transferrables = [];
+
+        var positions = [];
+        var normals = [];
+        var colors = [];
+
+        var properties = [];
+
+        var flats = [];
+        var point;
+
+        var result;
+        for (var i = 0; i < results.length; i++) {
+          result = results[i];
+
+          point = points[i];
+
+          // WORKERS: Making this a typed array will speed up transfer time
+          // As things stand this adds on a few milliseconds
+          flats.push(result.flat);
+
+          // WORKERS: result.attributes is actually an array of polygons for each
+          // feature, though the current logic isn't keeping these all together
+
+          var attributes;
+          for (var j = 0; j < result.attributes.length; j++) {
+            attributes = result.attributes[j];
+
+            positions.push(attributes.positions);
+            normals.push(attributes.normals);
+            colors.push(attributes.colors);
+
+            if (_properties) {
+              properties.push(Buffer.stringToUint8Array(JSON.stringify(polygon.properties)));
+            }
+          };
+        };
+
+        var mergedAttributes = {
+          positions: Buffer.mergeFloat32Arrays(positions),
+          normals: Buffer.mergeFloat32Arrays(normals),
+          colors: Buffer.mergeFloat32Arrays(colors)
+        };
+
+        transferrables.push(mergedAttributes.positions[0].buffer);
+        transferrables.push(mergedAttributes.positions[1].buffer);
+
+        transferrables.push(mergedAttributes.normals[0].buffer);
+        transferrables.push(mergedAttributes.normals[1].buffer);
+
+        transferrables.push(mergedAttributes.colors[0].buffer);
+        transferrables.push(mergedAttributes.colors[1].buffer);
+
+        var mergedProperties;
+        if (_properties) {
+          mergedProperties = Buffer.mergeUint8Arrays(properties);
+
+          transferrables.push(mergedProperties[0].buffer);
+          transferrables.push(mergedProperties[1].buffer);
+        }
+
+        var output = {
+          attributes: mergedAttributes,
+          flats: flats
+        };
+
+        if (_properties) {
+          output.properties = mergedProperties;
+        }
+
+        // TODO: Also return GeoJSON features that can be mapped to objects on
+        // the main thread. Allow user to provide filter / toggles to only return
+        // properties from the GeoJSON that they need (eg. don't return geometry,
+        // or don't return properties.height)
+        resolve({
+          data: output,
+          transferrables: transferrables
+        });
+      }).catch(reject);
+    });
+  }
+
   static ProcessGeoJSON(geojson, headers) {
     if (typeof geojson === 'string') {
       return GeoJSONWorkerLayer.RequestGeoJSON(geojson, headers);
@@ -681,6 +924,10 @@ class GeoJSONWorkerLayer extends Layer {
 
   _setPolylineMesh(attributes, attributeLengths, style, flat) {
     return PolylineLayer.SetMesh(attributes, attributeLengths, flat, style, this._options);
+  }
+
+  _setPointMesh(attributes, attributeLengths, style, flat) {
+    return PointLayer.SetMesh(attributes, attributeLengths, flat, style, this._options, this._world._environment._skybox);
   }
 
   // Set up and re-emit interaction events

--- a/src/layer/geometry/PointLayer.js
+++ b/src/layer/geometry/PointLayer.js
@@ -38,7 +38,7 @@ class PointLayer extends Layer {
       output: true,
       interactive: false,
       // THREE.Geometry or THREE.BufferGeometry to use for point output
-      geometry: null,
+      pointGeometry: null,
       // Custom material override
       //
       // TODO: Should this be in the style object?
@@ -160,7 +160,7 @@ class PointLayer extends Layer {
 
       // Use default geometry if none has been provided or the provided geometry
       // isn't valid
-      if (!options.geometry || (!options.geometry instanceof THREE.Geometry || !options.geometry instanceof THREE.BufferGeometry)) {
+      if (!options.pointGeometry || (!options.pointGeometry instanceof THREE.Geometry || !options.pointGeometry instanceof THREE.BufferGeometry)) {
         // Debug geometry for points is a thin bar
         //
         // TODO: Allow point geometry to be customised / overridden
@@ -175,9 +175,9 @@ class PointLayer extends Layer {
         geometry = new THREE.BufferGeometry().fromGeometry(_geometry);
       } else {
         if (options.geometry instanceof THREE.BufferGeometry) {
-          geometry = options.geometry;
+          geometry = options.pointGeometry;
         } else {
-          geometry = new THREE.BufferGeometry().fromGeometry(options.geometry);
+          geometry = new THREE.BufferGeometry().fromGeometry(options.pointGeometry);
         }
       }
 

--- a/src/layer/geometry/PointLayer.js
+++ b/src/layer/geometry/PointLayer.js
@@ -164,8 +164,8 @@ class PointLayer extends Layer {
         // Debug geometry for points is a thin bar
         //
         // TODO: Allow point geometry to be customised / overridden
-        var geometryWidth = Geo.metresToWorld(25, this._pointScale);
-        var geometryHeight = Geo.metresToWorld(200, this._pointScale);
+        var geometryWidth = Geo.metresToWorld(25, options.pointScale);
+        var geometryHeight = Geo.metresToWorld(200, options.pointScale);
         var _geometry = new THREE.BoxGeometry(geometryWidth, geometryHeight, geometryWidth);
 
         // Shift geometry up so it sits on the ground

--- a/src/layer/geometry/PointLayer.js
+++ b/src/layer/geometry/PointLayer.js
@@ -25,10 +25,12 @@
 import Layer from '../Layer';
 import extend from 'lodash.assign';
 import THREE from 'three';
+import Geo from '../../geo/Geo';
 import {latLon as LatLon} from '../../geo/LatLon';
 import {point as Point} from '../../geo/Point';
 import PickingMaterial from '../../engine/PickingMaterial';
 import Buffer from '../../util/Buffer';
+import PolygonLayer from './PolygonLayer';
 
 class PointLayer extends Layer {
   constructor(coordinates, options) {
@@ -40,8 +42,8 @@ class PointLayer extends Layer {
       // Custom material override
       //
       // TODO: Should this be in the style object?
-      material: null,
-      onMesh: null,
+      pointMaterial: null,
+      onPointMesh: null,
       // This default style is separate to Util.GeoJSON.defaultStyle
       style: {
         pointColor: '#ff0000'
@@ -57,42 +59,63 @@ class PointLayer extends Layer {
     // single point in the array)
     this._coordinates = (PointLayer.isSingle(coordinates)) ? [coordinates] : coordinates;
 
-    // Point features are always flat (for now at least)
-    //
-    // This won't always be the case once custom point objects / meshes are
-    // added
-    this._flat = true;
+    this._flat = false;
   }
 
   _onAdd(world) {
-    this._setCoordinates();
+    return new Promise((resolve, reject) => {
+      this._setCoordinates();
 
-    if (this._options.interactive) {
-      // Only add to picking mesh if this layer is controlling output
-      //
-      // Otherwise, assume another component will eventually add a mesh to
-      // the picking scene
-      if (this.isOutput()) {
-        this._pickingMesh = new THREE.Object3D();
-        this.addToPicking(this._pickingMesh);
+      if (this._options.interactive) {
+        // Only add to picking mesh if this layer is controlling output
+        //
+        // Otherwise, assume another component will eventually add a mesh to
+        // the picking scene
+        if (this.isOutput()) {
+          this._pickingMesh = new THREE.Object3D();
+          this.addToPicking(this._pickingMesh);
+        }
+
+        this._setPickingId();
+        this._addPickingEvents();
       }
 
-      this._setPickingId();
-      this._addPickingEvents();
-    }
+      // Store geometry representation as instances of THREE.BufferAttribute
+      PointLayer.SetBufferAttributes(this._projectedCoordinates, this._options).then((result) => {
+        this._bufferAttributes = Buffer.mergeAttributes(result.attributes);
+        this._flat = result.flat;
 
-    // Store geometry representation as instances of THREE.BufferAttribute
-    this._setBufferAttributes();
+        var attributeLengths = {
+          positions: 3,
+          normals: 3,
+          colors: 3
+        };
 
-    if (this.isOutput()) {
-      // Set mesh if not merging elsewhere
-      this._setMesh(this._bufferAttributes);
+        if (this._options.interactive) {
+          attributeLengths.pickingIds = 1;
+        }
 
-      // Output mesh
-      this.add(this._mesh);
-    }
+        if (this.isOutput()) {
+          var style = this._options.style;
 
-    return Promise.resolve(this);
+          // Set mesh if not merging elsewhere
+          // TODO: Dedupe with PolygonLayer as they are identical
+          PointLayer.SetMesh(this._bufferAttributes, attributeLengths, this._flat, style, this._options, this._world._environment._skybox).then((result) => {
+            // Output mesh
+            this.add(result.mesh);
+
+            if (result.pickingMesh) {
+              this._pickingMesh.add(result.pickingMesh);
+            }
+          });
+        }
+
+        result.attributes = null;
+        result = null;
+
+        resolve(this);
+      }).catch(reject);
+    });
   }
 
   // Return center of point as a LatLon
@@ -123,87 +146,78 @@ class PointLayer extends Layer {
     });
   }
 
-  // Create and store reference to THREE.BufferAttribute data for this layer
-  _setBufferAttributes() {
-    var height = 0;
+  static SetBufferAttributes(coordinates, options) {
+    return new Promise((resolve) => {
+      var height = 0;
 
-    // Convert height into world units
-    if (this._options.style.pointHeight) {
-      height = this._world.metresToWorld(this._options.style.pointHeight, this._pointScale);
-    }
+      // Convert height into world units
+      if (options.style.pointHeight) {
+        height = Geo.metresToWorld(options.style.pointHeight, options.pointScale);
+      }
 
-    var colour = new THREE.Color();
-    colour.set(this._options.style.pointColor);
+      var colour = new THREE.Color();
+      colour.set(options.style.pointColor);
 
-    var geometry;
+      // Use default geometry if none has been provided or the provided geometry
+      // isn't valid
+      if (!options.geometry || (!options.geometry instanceof THREE.Geometry || !options.geometry instanceof THREE.BufferGeometry)) {
+        // Debug geometry for points is a thin bar
+        //
+        // TODO: Allow point geometry to be customised / overridden
+        var geometryWidth = Geo.metresToWorld(25, this._pointScale);
+        var geometryHeight = Geo.metresToWorld(200, this._pointScale);
+        var _geometry = new THREE.BoxGeometry(geometryWidth, geometryHeight, geometryWidth);
 
-    // Use default geometry if none has been provided or the provided geometry
-    // isn't valid
-    if (!this._options.geometry || (!this._options.geometry instanceof THREE.Geometry || !this._options.geometry instanceof THREE.BufferGeometry)) {
-      // Debug geometry for points is a thin bar
-      //
-      // TODO: Allow point geometry to be customised / overridden
-      var geometryWidth = this._world.metresToWorld(25, this._pointScale);
-      var geometryHeight = this._world.metresToWorld(200, this._pointScale);
-      var _geometry = new THREE.BoxGeometry(geometryWidth, geometryHeight, geometryWidth);
+        // Shift geometry up so it sits on the ground
+        _geometry.translate(0, geometryHeight * 0.5, 0);
 
-      // Shift geometry up so it sits on the ground
-      _geometry.translate(0, geometryHeight * 0.5, 0);
-
-      // Pull attributes out of debug geometry
-      geometry = new THREE.BufferGeometry().fromGeometry(_geometry);
-    } else {
-      if (this._options.geometry instanceof THREE.BufferGeometry) {
-        geometry = this._options.geometry;
+        // Pull attributes out of debug geometry
+        geometry = new THREE.BufferGeometry().fromGeometry(_geometry);
       } else {
-        geometry = new THREE.BufferGeometry().fromGeometry(this._options.geometry);
-      }
-    }
-
-    // For each point
-    var attributes = this._projectedCoordinates.map(coordinate => {
-      var _vertices = [];
-      var _normals = [];
-      var _colours = [];
-
-      var _geometry = geometry.clone();
-
-      _geometry.translate(coordinate.x, height, coordinate.y);
-
-      var _vertices = _geometry.attributes.position.clone().array;
-      var _normals = _geometry.attributes.normal.clone().array;
-      var _colours = _geometry.attributes.color.clone().array;
-
-      for (var i = 0; i < _colours.length; i += 3) {
-        _colours[i] = colour.r;
-        _colours[i + 1] = colour.g;
-        _colours[i + 2] = colour.b;
-      }
-
-      var _point = {
-        vertices: _vertices,
-        normals: _normals,
-        colours: _colours
-      };
-
-      if (this._options.interactive && this._pickingId) {
-        // Inject picking ID
-        // point.pickingId = this._pickingId;
-        _point.pickingIds = new Float32Array(_vertices.length / 3);
-        for (var i = 0; i < _point.pickingIds.length; i++) {
-          _point.pickingIds[i] = this._pickingId;
+        if (options.geometry instanceof THREE.BufferGeometry) {
+          geometry = options.geometry;
+        } else {
+          geometry = new THREE.BufferGeometry().fromGeometry(options.geometry);
         }
       }
 
-      // Convert point representation to proper attribute arrays
-      // return this._toAttributes(_point);
-      return _point;
+      var attributes = coordinates.map((coordinate) => {
+        var _vertices = [];
+        var _normals = [];
+        var _colours = [];
+
+        var _geometry = geometry.clone();
+        _geometry.translate(coordinate.x, height, coordinate.y);
+
+        var _vertices = _geometry.attributes.position.clone().array;
+        var _normals = _geometry.attributes.normal.clone().array;
+        var _colours = _geometry.attributes.color.clone().array;
+
+        for (var i = 0; i < _colours.length; i += 3) {
+          _colours[i] = colour.r;
+          _colours[i + 1] = colour.g;
+          _colours[i + 2] = colour.b;
+        }
+
+        var _point = {
+          positions: _vertices,
+          normals: _normals,
+          colors: _colours
+        };
+
+        if (options.interactive && options.pickingId) {
+          // Inject picking ID
+          _point.pickingId = options.pickingId;
+        }
+
+        return _point;
+      });
+
+      resolve({
+        attributes: attributes,
+        flat: false
+      });
     });
-
-    this._bufferAttributes = Buffer.mergeAttributes(attributes);
-
-    // Original attributes are no longer required so free the memory
-    attributes = null;
   }
 
   getBufferAttributes() {
@@ -229,64 +243,68 @@ class PointLayer extends Layer {
     this._projectedCoordinates = null;
   }
 
-  // Create and store mesh from buffer attributes
-  //
-  // This is only called if the layer is controlling its own output
-  _setMesh(attributes) {
+  static SetMesh(attributes, attributeLengths, flat, style, options, skybox) {
     var geometry = new THREE.BufferGeometry();
 
-    // itemSize = 3 because there are 3 values (components) per vertex
-    geometry.addAttribute('position', new THREE.BufferAttribute(attributes.vertices, 3));
-    geometry.addAttribute('normal', new THREE.BufferAttribute(attributes.normals, 3));
-    geometry.addAttribute('color', new THREE.BufferAttribute(attributes.colours, 3));
-
-    if (attributes.pickingIds) {
-      geometry.addAttribute('pickingId', new THREE.BufferAttribute(attributes.pickingIds, 1));
+    for (var key in attributes) {
+      geometry.addAttribute(key.slice(0, -1), new THREE.BufferAttribute(attributes[key], attributeLengths[key]));
     }
 
     geometry.computeBoundingBox();
 
     var material;
-
-    if (this._options.material && this._options.material instanceof THREE.Material) {
-      material = this._options.material;
-    } else if (!this._world._environment._skybox) {
-      material = new THREE.MeshBasicMaterial({
-        vertexColors: THREE.VertexColors
-        // side: THREE.BackSide
+    if (options.pointMaterial && options.pointMaterial instanceof THREE.Material) {
+      material = options.pointMaterial;
+    } else if (!skybox) {
+      material = new THREE.MeshPhongMaterial({
+        vertexColors: THREE.VertexColors,
+        // side: THREE.BackSide,
+        transparent: style.transparent,
+        opacity: style.opacity,
+        blending: style.blending
       });
     } else {
       material = new THREE.MeshStandardMaterial({
-        vertexColors: THREE.VertexColors
-        // side: THREE.BackSide
+        vertexColors: THREE.VertexColors,
+        // side: THREE.BackSide,
+        transparent: style.transparent,
+        opacity: style.opacity,
+        blending: style.blending
       });
       material.roughness = 1;
       material.metalness = 0.1;
       material.envMapIntensity = 3;
-      material.envMap = this._world._environment._skybox.getRenderTarget();
+      material.envMap = skybox.getRenderTarget();
     }
 
     var mesh;
 
     // Pass mesh through callback, if defined
-    if (typeof this._options.onMesh === 'function') {
-      mesh = this._options.onMesh(geometry, material);
+    if (typeof options.onPolygonMesh === 'function') {
+      mesh = options.onPolygonMesh(geometry, material);
     } else {
       mesh = new THREE.Mesh(geometry, material);
 
       mesh.castShadow = true;
-      // mesh.receiveShadow = true;
+      mesh.receiveShadow = true;
     }
 
-    if (this._options.interactive && this._pickingMesh) {
+    if (flat) {
+      material.depthWrite = false;
+      mesh.renderOrder = 1;
+    }
+
+    if (options.interactive) {
       material = new PickingMaterial();
-      // material.side = THREE.BackSide;
+      material.side = THREE.BackSide;
 
       var pickingMesh = new THREE.Mesh(geometry, material);
-      this._pickingMesh.add(pickingMesh);
     }
 
-    this._mesh = mesh;
+    return Promise.resolve({
+      mesh: mesh,
+      pickingMesh: pickingMesh
+    });
   }
 
   // Convert and project coordinates
@@ -329,70 +347,11 @@ class PointLayer extends Layer {
         this._offset.x = -1 * _point.x;
         this._offset.y = -1 * _point.y;
 
-        this._pointScale = this._world.pointScale(latlon);
+        this._options.pointScale = this._world.pointScale(latlon);
       }
 
       return _point;
     });
-  }
-
-  // Transform line representation into attribute arrays that can be used by
-  // THREE.BufferGeometry
-  //
-  // TODO: Can this be simplified? It's messy and huge
-  _toAttributes(line) {
-    // Three components per vertex
-    var vertices = new Float32Array(line.verticesCount * 3);
-    var colours = new Float32Array(line.verticesCount * 3);
-
-    var pickingIds;
-    if (line.pickingId) {
-      // One component per vertex
-      pickingIds = new Float32Array(line.verticesCount);
-    }
-
-    var _vertices = line.vertices;
-    var _colour = line.colours;
-
-    var _pickingId;
-    if (pickingIds) {
-      _pickingId = line.pickingId;
-    }
-
-    var lastIndex = 0;
-
-    for (var i = 0; i < _vertices.length; i++) {
-      var ax = _vertices[i][0];
-      var ay = _vertices[i][1];
-      var az = _vertices[i][2];
-
-      var c1 = _colour[i];
-
-      vertices[lastIndex * 3 + 0] = ax;
-      vertices[lastIndex * 3 + 1] = ay;
-      vertices[lastIndex * 3 + 2] = az;
-
-      colours[lastIndex * 3 + 0] = c1[0];
-      colours[lastIndex * 3 + 1] = c1[1];
-      colours[lastIndex * 3 + 2] = c1[2];
-
-      if (pickingIds) {
-        pickingIds[lastIndex] = _pickingId;
-      }
-
-      lastIndex++;
-    }
-
-    var attributes = {
-      vertices: vertices,
-      colours: colours
-    };
-
-    if (pickingIds) {
-      attributes.pickingIds = pickingIds;
-    }
-
-    return attributes;
   }
 
   // Returns true if the line is flat (has no height)


### PR DESCRIPTION
# Description

The current implementation of Web Worker layers within ViziCities only supports polygon geometry. Point geometry is required for 100% coverage of GeoJSON.

# Solution

This PR adds point support for Web Worker layers as well as generally tidying up point logic across the board.