### PR TITLE
Added 2D outline support for polygons

### DIFF
--- a/examples/geojson/main.js
+++ b/examples/geojson/main.js
@@ -19,6 +19,8 @@ VIZI.geoJSONLayer('http://vector.mapzen.com/osm/roads,pois,buildings/14/4824/615
   output: true,
   style: {
     color: '#ff0000',
+    outline: true,
+    outlineColor: '#580000',
     lineColor: '#0000ff',
     lineRenderOrder: 1,
     pointColor: '#00cc00'

--- a/examples/web-workers-geojson/main.js
+++ b/examples/web-workers-geojson/main.js
@@ -23,6 +23,8 @@ world.createWorkers(7).then(() => {
     output: true,
     style: {
       color: '#ff0000',
+      outline: true,
+      outlineColor: '#580000',
       lineColor: '#0000ff',
       lineRenderOrder: 1,
       pointColor: '#00cc00'

--- a/src/util/GeoJSON.js
+++ b/src/util/GeoJSON.js
@@ -23,6 +23,8 @@ var shadow  = new THREE.Color(0x666666);
 var GeoJSON = (function() {
   var defaultStyle = {
     color: '#ffffff',
+    outline: false,
+    outlineColor: '#000000',
     transparent: false,
     opacity: 1,
     blending: THREE.NormalBlending,


### PR DESCRIPTION
# Description

There's no way right now to visualise polygon boundaries without using unique colours / shades for every single polygon. This makes visualisation with lots of neighbouring polygons hard to visualise without making things complex and garish.

# Solution

An `outline` option has been added to the style property of polygon layers that toggles the rendering of a thin outline around each 2D polygon on that layer. An accompanying `outlineColor` style option allows you to further define the colour of the outline (default is black).

# Screenshots

![screen shot 2016-09-13 at 11 20 24](https://cloud.githubusercontent.com/assets/22612/18470375/25f73926-79a4-11e6-8242-38f11b33cfe2.png)

# Limitations

This will only outline 2D geometry, so if applied to a polygon layer which is extruded the outlines will only appear on the ground plane. 3D outlines can be implemented using [`THREE.EdgesGeometry`](https://github.com/mrdoob/three.js/tree/dev/src/extras/geometries/EdgesGeometry.js) though that implementation will be deferred to a future PR.