### PR TITLE
Added event to listen for tile list updates on a layer

### DIFF
--- a/examples/tile-events/index.html
+++ b/examples/tile-events/index.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Tile Events ViziCities Example</title>
+  <link rel="stylesheet" href="main.css">
+  <link rel="stylesheet" href="../../dist/vizicities.css">
+</head>
+<body>
+  <div id="world"></div>
+
+  <script src="../vendor/three.min.js"></script>
+  <script src="../vendor/TweenMax.min.js"></script>
+  <script src="../../dist/vizicities.min.js"></script>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/tile-events/main.css
+++ b/examples/tile-events/main.css
@@ -1,0 +1,4 @@
+* { margin: 0; padding: 0; }
+html, body { height: 100%; overflow: hidden;}
+
+#world { height: 100%; }

--- a/examples/tile-events/main.js
+++ b/examples/tile-events/main.js
@@ -1,0 +1,25 @@
+// Manhattan
+var coords = [40.739940, -73.988801];
+
+var world = VIZI.world('world', {
+  skybox: false,
+  postProcessing: false
+}).setView(coords);
+
+// Add controls
+VIZI.Controls.orbit().addTo(world);
+
+// CartoDB basemap
+var imageTiles = VIZI.imageTileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+  attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+});
+
+imageTiles.addTo(world).then(() => {
+  console.log('Added image tile layer to world');
+});
+
+// Will be emitted every time the image layer updates the tile list
+// All tiles in view are sent with each update
+imageTiles.on('tilesList', (tiles) => {
+  console.log(tiles);
+});

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -126,6 +126,9 @@ class TileLayer extends Layer {
         this._tilesPicking.add(tile.getPickingMesh());
       }
     });
+
+    // Emit event notifying of new tiles
+    this.emit('tilesList', this._tileList.map((tile) => tile._tile));
   }
 
   // Works out tiles in the view frustum and stores them in an array


### PR DESCRIPTION
# Description

There's currently no way to easily be notified of tile updates to a tile layer, the closest method is to periodically check the `_tiles` property.

# Solution

A `tilesList ` event has been added to all tile layers that is emitted every time the tiles for a layer are updated and sent for output. The payload is an array of tile coordinates in the format `[x, y, z]`. All visible tiles are sent on each update, rather than only those that changed between updates.