### PR TITLE
Expose tile components and change payload of tile event

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -84,7 +84,9 @@ class Layer extends EventEmitter {
   }
 
   // Must return a promise
-  _onAdd(world) {}
+  _onAdd(world) {
+    return Promise.resolve(this);
+  }
 
   getPickingId() {
     if (this._world._engine._picking) {

--- a/src/layer/LayerGroup.js
+++ b/src/layer/LayerGroup.js
@@ -30,7 +30,9 @@ class LayerGroup extends Layer {
     this._world.removeLayer(layer);
   }
 
-  _onAdd(world) {}
+  _onAdd(world) {
+    return Promise.resolve(this);
+  }
 
   // Destroy the layers and remove them from the scene and memory
   destroy() {

--- a/src/layer/tile/GeoJSONTile.js
+++ b/src/layer/tile/GeoJSONTile.js
@@ -237,7 +237,8 @@ class GeoJSONTile extends Tile {
       this._request = reqwest({
         url: url,
         type: 'json',
-        crossOrigin: true
+        crossOrigin: true,
+        headers: this._options.headers
       }).then(res => {
         // Clear request reference
         this._request = null;
@@ -261,7 +262,7 @@ class GeoJSONTile extends Tile {
     // Using this creates a huge amount of memory due to the quantity of tiles
     this._geojsonLayer = GeoJSONClass(data, this._options);
     this._geojsonLayer.addTo(this._world).then(() => {
-      this._mesh = this._geojsonLayer._object3D;
+      this._mesh.add(this._geojsonLayer._object3D);
       this._pickingMesh = this._geojsonLayer._pickingMesh;
 
       // Free the GeoJSON memory as we don't need it

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -128,7 +128,7 @@ class TileLayer extends Layer {
     });
 
     // Emit event notifying of new tiles
-    this.emit('tilesList', this._tileList.map((tile) => tile._tile));
+    this.emit('tilesList', this._tileList.map((tile) => tile));
   }
 
   // Works out tiles in the view frustum and stores them in an array

--- a/src/vizicities.js
+++ b/src/vizicities.js
@@ -4,10 +4,12 @@ import Controls from './controls/index';
 import Geo from './geo/Geo.js';
 
 import Layer, {layer} from './layer/Layer';
+import LayerGroup, {layerGroup} from './layer/LayerGroup';
 import EnvironmentLayer, {environmentLayer} from './layer/environment/EnvironmentLayer';
 import ImageTileLayer, {imageTileLayer} from './layer/tile/ImageTileLayer';
 import GeoJSONTileLayer, {geoJSONTileLayer} from './layer/tile/GeoJSONTileLayer';
 import TopoJSONTileLayer, {topoJSONTileLayer} from './layer/tile/TopoJSONTileLayer';
+import GeoJSONTile, {geoJSONTile} from './layer/tile/GeoJSONTile';
 import GeoJSONLayer, {geoJSONLayer} from './layer/GeoJSONLayer';
 import TopoJSONLayer, {topoJSONLayer} from './layer/TopoJSONLayer';
 import GeoJSONWorkerLayer, {geoJSONWorkerLayer} from './layer/GeoJSONWorkerLayer';
@@ -39,6 +41,8 @@ const VIZI = {
   imageTileLayer: imageTileLayer,
   GeoJSONTileLayer: GeoJSONTileLayer,
   geoJSONTileLayer: geoJSONTileLayer,
+  GeoJSONTile: GeoJSONTile,
+  geoJSONTile: geoJSONTile,
   TopoJSONTileLayer: TopoJSONTileLayer,
   topoJSONTileLayer: topoJSONTileLayer,
   GeoJSONLayer: GeoJSONLayer,


### PR DESCRIPTION
# Description

There's no way to utilise tile components using the `VIZI` namespace. 

# Solution

Expose tile components on `VIZI` namespace and emit tiles within update events.