### PR TITLE
Fixed reference to TopoJSON module

### DIFF
--- a/src/util/GeoJSON.js
+++ b/src/util/GeoJSON.js
@@ -3,7 +3,7 @@
  */
 
 import THREE from 'three';
-import topojson from 'topojson';
+import * as topojson from 'topojson';
 import geojsonMerge from 'geojson-merge';
 import earcut from 'earcut';
 import extrudePolygon from './extrudePolygon';


### PR DESCRIPTION
# Description

TopoJSON errors are being triggered when using a custom build of ViziCities.

See: https://github.com/UDST/vizicities/issues/176
# Solution

Reference to TopoJSON module has changed and so updating it according to the new TopoJSON documentation fixes the issue.
