### PR TITLE
Fix layering issues with outlines

### DIFF
--- a/examples/web-workers-outlines/index.html
+++ b/examples/web-workers-outlines/index.html
@@ -1,0 +1,18 @@
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Web Workers Outlines ViziCities Example</title>
+  <link rel="stylesheet" href="main.css">
+  <link rel="stylesheet" href="../../dist/vizicities.css">
+</head>
+<body>
+  <div id="world"></div>
+
+  <script src="../vendor/three.min.js"></script>
+  <script src="../vendor/TweenMax.min.js"></script>
+  <script src="../../dist/vizicities.min.js"></script>
+
+  <script src="main.js"></script>
+</body>
+</html>

--- a/examples/web-workers-outlines/main.css
+++ b/examples/web-workers-outlines/main.css
@@ -1,0 +1,4 @@
+* { margin: 0; padding: 0; }
+html, body { height: 100%; overflow: hidden;}
+
+#world { height: 100%; }

--- a/examples/web-workers-outlines/main.js
+++ b/examples/web-workers-outlines/main.js
@@ -1,0 +1,49 @@
+// Manhattan
+var coords = [40.739940, -73.988801];
+
+var world = VIZI.world('world', {
+  skybox: false,
+  postProcessing: false
+}).setView(coords);
+
+// Add controls
+VIZI.Controls.orbit().addTo(world);
+
+// Leave a single CPU for the main browser thread
+world.createWorkers(7).then(() => {
+  console.log('Workers ready');
+
+  // CartoDB basemap
+  VIZI.imageTileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+  }).addTo(world).then(() => {
+    console.log('Added image tile layer to world');
+  });
+
+  // Buildings from Mapzen
+  VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+    workers: true,
+    interactive: false,
+    maxLOD: 17,
+    style: function(feature) {
+      return {
+        color: Math.random() * 0xffffff,
+        outline: true,
+        outlineColor: '#000000',
+
+        // Uncomment to create a thicker outlines that appears below the
+        // polygon layer, sort of creating an outline around city blocks and
+        // adjacent buildings
+        // outlineRenderOrder: 0,
+        // outlineWidth: 2
+      }
+    },
+    filter: function(feature) {
+      // Don't show points
+      return feature.geometry.type !== 'Point';
+    },
+    attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, <a href="http://whosonfirst.mapzen.com#License">Who\'s On First</a>.'
+  }).addTo(world).then(() => {
+    console.log('Added TopoJSON layer to world');
+  });
+});

--- a/examples/web-workers-outlines/vizicities-worker.js
+++ b/examples/web-workers-outlines/vizicities-worker.js
@@ -1,0 +1,61 @@
+importScripts('../vendor/three.min.js');
+
+// Special version of ViziCities without controls (no DOM errors)
+importScripts('../../dist/vizicities-worker.min.js');
+
+const DEBUG = false;
+
+if (DEBUG) { console.log('Worker started', performance.now()); }
+
+// Send startup message to main thread
+postMessage({
+  type: 'startup',
+  payload: performance.now()
+});
+
+// Recieve message from main thread
+onmessage = (event) => {
+  if (!event.data.method) {
+    postMessage({
+      type: 'error',
+      payload: 'No method provided'
+    });
+
+    return;
+  }
+
+  var time = performance.now();
+  if (DEBUG) { console.log('Message received from main thread', time, event.data); }
+  // if (DEBUG) console.log('Time to receive message', time - event.data);
+
+  // Run method
+  // if (!methods[event.data.method]) {
+  //   postMessage({
+  //     type: 'error',
+  //     payload: 'Method not found'
+  //   });
+
+  //   return;
+  // }
+
+  var methods = event.data.method.split('.');
+
+  var _method = VIZI[methods[0]];
+
+  if (methods.length > 1) {
+    for (var i = 1; i < methods.length; i++) {
+      _method = _method[methods[i]];
+    }
+  }
+
+  // Call method with given arguments
+  _method.apply(this, event.data.args).then((result) => {
+    console.log('Message sent from worker', performance.now());
+
+    // Return results
+    postMessage({
+      type: 'result',
+      payload: result.data
+    }, result.transferrables);
+  });
+};

--- a/src/layer/GeoJSONLayer.js
+++ b/src/layer/GeoJSONLayer.js
@@ -245,7 +245,7 @@ class GeoJSONLayer extends LayerGroup {
           style = (typeof this._options.style === 'function') ? this._options.style(this._geojson.features[0]) : this._options.style;
           style = extend({}, GeoJSON.defaultStyle, style);
 
-          this._setPolygonMesh(mergedPolygonAttributes, polygonAttributeLengths, polygonFlat).then((result) => {
+          this._setPolygonMesh(mergedPolygonAttributes, polygonAttributeLengths, style, polygonFlat).then((result) => {
             this._polygonMesh = result.mesh;
             this.add(this._polygonMesh);
 

--- a/src/layer/GeoJSONWorkerLayer.js
+++ b/src/layer/GeoJSONWorkerLayer.js
@@ -283,11 +283,13 @@ class GeoJSONWorkerLayer extends Layer {
 
       var outputPromises = [];
 
+      var style;
+
       if (polygonAttributes.length > 0) {
         var mergedPolygonAttributes = Buffer.mergeAttributes(polygonAttributes);
 
         // TODO: Make this work when style is a function per feature
-        var style = (typeof this._options.style === 'function') ? this._options.style(objects[0]) : this._options.style;
+        style = (typeof this._options.style === 'function') ? this._options.style(objects[0]) : this._options.style;
         style = extend({}, GeoJSON.defaultStyle, style);
 
         outputPromises.push(this._setPolygonMesh(mergedPolygonAttributes, polygonAttributeLengths, style, polygonFlat));
@@ -296,8 +298,18 @@ class GeoJSONWorkerLayer extends Layer {
       if (polygonOutlineAttributes.length > 0) {
         var mergedPolygonOutlineAttributes = Buffer.mergeAttributes(polygonOutlineAttributes);
 
-        var style = (typeof this._options.style === 'function') ? this._options.style(objects[0]) : this._options.style;
+        style = (typeof this._options.style === 'function') ? this._options.style(objects[0]) : this._options.style;
         style = extend({}, GeoJSON.defaultStyle, style);
+
+        if (style.outlineRenderOrder !== undefined) {
+          style.lineRenderOrder = style.outlineRenderOrder;
+        } else {
+          style.lineRenderOrder = (style.renderOrder) ? style.renderOrder + 1 : 2;
+        }
+
+        if (style.outlineWidth) {
+          style.lineWidth = style.outlineWidth;
+        }
 
         outputPromises.push(this._setPolylineMesh(mergedPolygonOutlineAttributes, polygonOutlineAttributeLengths, style, true));
       }

--- a/src/layer/geometry/PointLayer.js
+++ b/src/layer/geometry/PointLayer.js
@@ -291,7 +291,7 @@ class PointLayer extends Layer {
 
     if (flat) {
       material.depthWrite = false;
-      mesh.renderOrder = 1;
+      mesh.renderOrder = 3;
     }
 
     if (options.interactive) {

--- a/src/layer/geometry/PointLayer.js
+++ b/src/layer/geometry/PointLayer.js
@@ -291,7 +291,7 @@ class PointLayer extends Layer {
 
     if (flat) {
       material.depthWrite = false;
-      mesh.renderOrder = 3;
+      mesh.renderOrder = 1;
     }
 
     if (options.interactive) {

--- a/src/layer/geometry/PolygonLayer.js
+++ b/src/layer/geometry/PolygonLayer.js
@@ -404,7 +404,7 @@ class PolygonLayer extends Layer {
 
     if (flat) {
       material.depthWrite = false;
-      mesh.renderOrder = 1;
+      mesh.renderOrder = style.renderOrder || 1;
     }
 
     if (options.interactive) {

--- a/src/layer/tile/ImageTile.js
+++ b/src/layer/tile/ImageTile.js
@@ -70,6 +70,8 @@ class ImageTile extends Tile {
 
     localMesh.receiveShadow = true;
 
+    localMesh.renderOrder = -1;
+
     mesh.add(localMesh);
     mesh.renderOrder = 0.1;
 

--- a/src/layer/tile/ImageTile.js
+++ b/src/layer/tile/ImageTile.js
@@ -69,11 +69,10 @@ class ImageTile extends Tile {
     localMesh.rotation.x = -90 * Math.PI / 180;
 
     localMesh.receiveShadow = true;
-
-    localMesh.renderOrder = -1;
+    localMesh.renderOrder = 0;
 
     mesh.add(localMesh);
-    mesh.renderOrder = 0.1;
+    mesh.renderOrder = 0;
 
     mesh.position.x = this._center[0];
     mesh.position.z = this._center[1];

--- a/src/layer/tile/ImageTileLayer.js
+++ b/src/layer/tile/ImageTileLayer.js
@@ -83,7 +83,7 @@ class ImageTileLayer extends TileLayer {
         }
 
         var mesh = new THREE.Mesh(geom, baseMaterial);
-        mesh.renderOrder = 0;
+        mesh.renderOrder = -1;
         mesh.rotation.x = -90 * Math.PI / 180;
 
         // TODO: It might be overkill to receive a shadow on the base layer as it's


### PR DESCRIPTION
## Description

The existing outline behaviour currently has a layering issue that causes the outlines to intersect with the polygon geometry and basemap.
## Solution

Hard-coded layer values have been added to ensure the outlines stay on top of the polygon geometry by default. Two new style options have also been added to allow for refined control of outlines:
- `style.outlineWidth` overrides the width of the outlines
- `style.outlineRenderOrder` overrides the render (layer) order of the outlines

Together, these new options allow you to override the outline behaviour and do interesting things like forcing the outlines to appear thicker but below the polygon layer. This results in an effect where adjacent polygons appear to only have outlines around their combined outline rather than around each individual polygon.
## Screenshots

![screen shot 2016-10-06 at 11 39 27](https://cloud.githubusercontent.com/assets/22612/19151038/5a1a5672-8bc2-11e6-8c31-abe7ceaf0743.png)

![screen shot 2016-10-06 at 11 38 31](https://cloud.githubusercontent.com/assets/22612/19151040/5d6337cc-8bc2-11e6-9af4-5ddad19b95e5.png)

![screen shot 2016-10-06 at 12 13 28](https://cloud.githubusercontent.com/assets/22612/19151045/64b51d6a-8bc2-11e6-9579-e888e8c514ba.png)
