### PR TITLE
Added a simple layer visibility API

### DIFF
--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -123,6 +123,16 @@ class Layer extends EventEmitter {
     return this._options.outputToScene;
   }
 
+  // TODO: Also hide any attached DOM layers
+  hide() {
+    this._object3D.visible = false;
+  }
+
+  // TODO: Also show any attached DOM layers
+  show() {
+    this._object3D.visible = true;
+  }
+
   // Destroys the layer and removes it from the scene and memory
   destroy() {
     if (this._object3D && this._object3D.children) {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -347,6 +347,17 @@ class TileLayer extends Layer {
     tile.destroy();
   }
 
+  show() {
+    this._stop = false;
+    this._calculateLOD();
+    super.show();
+  }
+
+  hide() {
+    this._stop = true;
+    super.hide();
+  }
+
   // Destroys the layer and removes it from the scene and memory
   destroy() {
     if (this._tiles.children) {


### PR DESCRIPTION
## Description

There's currently no simple method for hiding and showing layers and handling any subsequent logic that has to occur for different layer types.
## Solution

Two new methods have been added to `VIZI.Layer` that can be used to show or hide layers (`Layer.show()` and `Layer.hide()`). These methods are also present on tile layers and will pause the tile requests while the layer is hidden.
