### PR TITLE
Fix layer pause on visibility update

### DIFF
--- a/src/layer/tile/GeoJSONTileLayer.js
+++ b/src/layer/tile/GeoJSONTileLayer.js
@@ -117,6 +117,16 @@ class GeoJSONTileLayer extends TileLayer {
     return new GeoJSONTile(quadcode, this._path, layer, newOptions);
   }
 
+  hide() {
+    this._pauseOutput = true;
+    super.hide();
+  }
+
+  show() {
+    this._pauseOutput = false;
+    super.show();
+  }
+
   // Destroys the layer and removes it from the scene and memory
   destroy() {
     this._world.off('preUpdate', this._throttledWorldUpdate);


### PR DESCRIPTION
## Description

Currently the output of a tile layer can remain paused even when a layer is asked to be made visible again.
## Solution

Tile layer paused state is now manually set during layer visibility changes.
