### PR TITLE
Fix an issue with worker layers erroring after destruction

### DIFF
--- a/src/layer/GeoJSONWorkerLayer.js
+++ b/src/layer/GeoJSONWorkerLayer.js
@@ -146,7 +146,7 @@ class GeoJSONWorkerLayer extends Layer {
         if (processPromises.length > 0) {
           Promise.all(processPromises).then(() => {
             resolve();
-          });
+          }).catch(reject);
         } else {
           resolve();
         }
@@ -333,7 +333,7 @@ class GeoJSONWorkerLayer extends Layer {
         }
 
         resolve();
-      });
+      }).catch(reject);
     });
   }
 
@@ -439,7 +439,7 @@ class GeoJSONWorkerLayer extends Layer {
           }
 
           resolve();
-        });
+        }).catch(reject);
       } else {
         resolve();
       }
@@ -550,7 +550,7 @@ class GeoJSONWorkerLayer extends Layer {
           }
 
           resolve();
-        });
+        }).catch(reject);
       } else {
         resolve();
       }
@@ -1079,14 +1079,26 @@ class GeoJSONWorkerLayer extends Layer {
   //
   // Could make this an abstract method for each geometry layer
   _setPolygonMesh(attributes, attributeLengths, style, flat) {
+    if (!this._world) {
+      return Promise.reject();
+    }
+
     return PolygonLayer.SetMesh(attributes, attributeLengths, flat, style, this._options, this._world._environment._skybox);
   }
 
   _setPolylineMesh(attributes, attributeLengths, style, flat) {
+    if (!this._world) {
+      return Promise.reject();
+    }
+
     return PolylineLayer.SetMesh(attributes, attributeLengths, flat, style, this._options);
   }
 
   _setPointMesh(attributes, attributeLengths, style, flat) {
+    if (!this._world) {
+      return Promise.reject();
+    }
+
     return PointLayer.SetMesh(attributes, attributeLengths, flat, style, this._options, this._world._environment._skybox);
   }
 

--- a/src/layer/tile/GeoJSONTile.js
+++ b/src/layer/tile/GeoJSONTile.js
@@ -349,7 +349,7 @@ class GeoJSONTile extends Tile {
 
       this._ready = true;
       // console.timeEnd(this._tile);
-    });
+    }).catch(() => {});
   }
 
   _abortRequest() {

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -63,6 +63,8 @@ class TileLayer extends Layer {
 
     super(_options);
 
+    this._destroy = false;
+
     this._tileCache = new TileCache(this._options.maxCache, tile => {
       this._destroyTile(tile);
     });
@@ -102,7 +104,7 @@ class TileLayer extends Layer {
 
   // Update and output tiles from the previous LOD checklist
   _outputTiles() {
-    if (!this._tiles) {
+    if (!this._tiles || this._destroy) {
       return;
     }
 
@@ -135,7 +137,7 @@ class TileLayer extends Layer {
   //
   // Does not output the tiles, deferring this to _outputTiles()
   _calculateLOD() {
-    if (this._stop || !this._world) {
+    if (this._stop || !this._world || this._destroy) {
       return;
     }
 
@@ -370,6 +372,8 @@ class TileLayer extends Layer {
 
   // Destroys the layer and removes it from the scene and memory
   destroy() {
+    this._destroy = true;
+
     if (this._tiles.children) {
       // Remove all tiles
       for (var i = this._tiles.children.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Description

Worker layers currently error out on destruction when tiles are still being requested as the layer is destroyed.
## Solution

Checks for the local `world` reference as well as better promise rejection handling fixes these errors.
