### PR TITLE
Update Mapzen endpoints

### DIFF
--- a/examples/all-the-things/main.js
+++ b/examples/all-the-things/main.js
@@ -18,7 +18,7 @@ VIZI.imageTileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}
 }).addTo(world);
 
 // Buildings and roads from Mapzen (polygons and linestrings)
-var topoJSONTileLayer = VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings,roads/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+var topoJSONTileLayer = VIZI.topoJSONTileLayer('https://tile.mapzen.com/mapzen/vector/v1/buildings,roads/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
   interactive: false,
   style: function(feature) {
     var height;

--- a/examples/basic/main.js
+++ b/examples/basic/main.js
@@ -17,7 +17,7 @@ VIZI.imageTileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}
 });;
 
 // Buildings from Mapzen
-VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+VIZI.topoJSONTileLayer('https://tile.mapzen.com/mapzen/vector/v1/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
   interactive: false,
   style: function(feature) {
     var height;

--- a/examples/colour-by-height/main.js
+++ b/examples/colour-by-height/main.js
@@ -18,7 +18,7 @@ VIZI.imageTileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}
 var colourScale = chroma.scale('YlOrBr').domain([0,200]);
 
 // Buildings from Mapzen
-VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+VIZI.topoJSONTileLayer('https://tile.mapzen.com/mapzen/vector/v1/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
   interactive: false,
   style: function(feature) {
     var height;

--- a/examples/geojson/main.js
+++ b/examples/geojson/main.js
@@ -15,7 +15,7 @@ VIZI.imageTileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}
 }).addTo(world);
 
 // Mapzen GeoJSON tile including points, linestrings and polygons
-VIZI.geoJSONLayer('http://vector.mapzen.com/osm/roads,pois,buildings/14/4824/6159.json', {
+VIZI.geoJSONLayer('https://tile.mapzen.com/mapzen/vector/v1/roads,pois,buildings/14/4824/6159.json', {
   output: true,
   style: {
     color: '#ff0000',

--- a/examples/web-workers-all-the-things/main.js
+++ b/examples/web-workers-all-the-things/main.js
@@ -22,7 +22,7 @@ world.createWorkers(7).then(() => {
   }).addTo(world);
 
   // Buildings and roads from Mapzen (polygons and linestrings)
-  var topoJSONTileLayer = VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings,roads/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+  var topoJSONTileLayer = VIZI.topoJSONTileLayer('https://tile.mapzen.com/mapzen/vector/v1/buildings,roads/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
     workers: true,
     interactive: false,
     style: function(feature) {

--- a/examples/web-workers-basic/main.js
+++ b/examples/web-workers-basic/main.js
@@ -21,7 +21,7 @@ world.createWorkers(7).then(() => {
   });;
 
   // Buildings from Mapzen
-  VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+  VIZI.topoJSONTileLayer('https://tile.mapzen.com/mapzen/vector/v1/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
     workers: true,
     interactive: false,
     style: function(feature) {

--- a/examples/web-workers-geojson/main.js
+++ b/examples/web-workers-geojson/main.js
@@ -19,7 +19,7 @@ world.createWorkers(7).then(() => {
   }).addTo(world);
 
   // Mapzen GeoJSON tile including points, linestrings and polygons
-  VIZI.geoJSONWorkerLayer('http://vector.mapzen.com/osm/roads,pois,buildings/14/4824/6159.json', {
+  VIZI.geoJSONWorkerLayer('https://tile.mapzen.com/mapzen/vector/v1/roads,pois,buildings/14/4824/6159.json', {
     output: true,
     style: {
       color: '#ff0000',

--- a/examples/web-workers-outlines/main.js
+++ b/examples/web-workers-outlines/main.js
@@ -21,7 +21,7 @@ world.createWorkers(7).then(() => {
   });
 
   // Buildings from Mapzen
-  VIZI.topoJSONTileLayer('https://vector.mapzen.com/osm/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
+  VIZI.topoJSONTileLayer('https://tile.mapzen.com/mapzen/vector/v1/buildings/{z}/{x}/{y}.topojson?api_key=vector-tiles-NT5Emiw', {
     workers: true,
     interactive: false,
     maxLOD: 17,


### PR DESCRIPTION
## Description

[Mapzen has updated it's vector tile endpoints](https://mapzen.com/blog/v1-vector-tile-service/) and, while the old endpoints still work, it's a good idea to update to the latest endpoints as soon as possible.

## Solution

All the examples have been updated to use the latest version of the Mapzen endpoints.