### PR TITLE
Allow workers to fail properly with bad tile endpoints

### DIFF
--- a/src/layer/GeoJSONWorkerLayer.js
+++ b/src/layer/GeoJSONWorkerLayer.js
@@ -150,7 +150,7 @@ class GeoJSONWorkerLayer extends Layer {
         } else {
           resolve();
         }
-      });
+      }).catch(reject);
     });
   }
 
@@ -775,7 +775,7 @@ class GeoJSONWorkerLayer extends Layer {
             });
           });
         });
-      });
+      }).catch(reject);
     });
   }
 

--- a/src/util/WorkerPool.js
+++ b/src/util/WorkerPool.js
@@ -98,7 +98,7 @@ class WorkerPool {
 
       // Return result in deferred task promise
       task.deferred.resolve(result);
-    });
+    }).catch(task.deferred.reject);
   }
 }
 

--- a/src/util/WorkerPool.js
+++ b/src/util/WorkerPool.js
@@ -98,7 +98,12 @@ class WorkerPool {
 
       // Return result in deferred task promise
       task.deferred.resolve(result);
-    }).catch(task.deferred.reject);
+    }).catch((err) => {
+      // Trigger task processing
+      this.processTasks();
+
+      task.deferred.reject(err);
+    });
   }
 }
 


### PR DESCRIPTION
## Description

If a tile endpoint fails then it prevents the worker processes from being released and eventually causes no workers to be available for future process.

## Solution

Adding in `reject()` statements to allow the workers to fail properly means that they get released for future work.