### PR TITLE
Emit changed flag on controls end event

### DIFF
--- a/src/controls/Controls.Orbit.js
+++ b/src/controls/Controls.Orbit.js
@@ -16,6 +16,10 @@ class Orbit extends EventEmitter {
   // There's currently no distinction between pan, orbit and zoom events
   _initEvents() {
     this._controls.addEventListener('start', (event) => {
+      this.startPosition = this._controls.target.clone();
+      this.startPolar = this._controls.getPolarAngle();
+      this.startAzimuth = this._controls.getAzimuthalAngle();
+
       this._world.emit('controlsMoveStart', event.target.target);
     });
 
@@ -24,7 +28,29 @@ class Orbit extends EventEmitter {
     });
 
     this._controls.addEventListener('end', (event) => {
-      this._world.emit('controlsMoveEnd', event.target.target);
+      var endPosition = this._controls.target.clone();
+      var endPolar = this._controls.getPolarAngle();
+      var endAzimuth = this._controls.getAzimuthalAngle();
+
+      // Did controls change?
+      var changed = false;
+
+      // Panned
+      if (Math.abs(endPosition.distanceTo(this.startPosition)) > 0) {
+        changed = true;
+      }
+
+      // Tilted
+      if (Math.abs(endPolar - this.startPolar) > 0) {
+        changed = true;
+      }
+
+      // Obited
+      if (Math.abs(endAzimuth - this.startAzimuth) > 0) {
+        changed = true;
+      }
+
+      this._world.emit('controlsMoveEnd', event.target.target, changed);
     });
   }
 


### PR DESCRIPTION
## Description

Control events are emitted regardless of whether anything actually changed so it's hard to tell if the view moved at all.

## Solution

A `changed` flag is sent with the `controlsMoveEnd` events that signifies whether the view moved or not.