### PR TITLE
Force render order

### DIFF
--- a/src/layer/geometry/PolygonLayer.js
+++ b/src/layer/geometry/PolygonLayer.js
@@ -403,7 +403,9 @@ class PolygonLayer extends Layer {
     }
 
     if (flat || style.renderOrder !== undefined) {
-      material.depthWrite = false;
+      if (!style.ignoreDepth) {
+        material.depthWrite = false;
+      }
 
       var renderOrder = (style.renderOrder !== undefined) ? style.renderOrder : 3;
       mesh.renderOrder = renderOrder;

--- a/src/layer/geometry/PolygonLayer.js
+++ b/src/layer/geometry/PolygonLayer.js
@@ -402,7 +402,7 @@ class PolygonLayer extends Layer {
       mesh.receiveShadow = true;
     }
 
-    if (flat) {
+    if (flat || style.renderOrder !== undefined) {
       material.depthWrite = false;
 
       var renderOrder = (style.renderOrder !== undefined) ? style.renderOrder : 3;


### PR DESCRIPTION
## Description

It's currently impossible to impose a render order on a polygon layer unless it is considered flat.

## Solution

Allow for render order to be set if one exists while also allowing the depth write to be ignored if required.