### PR TITLE
Fix issues with IE and Safari

### DIFF
--- a/examples/web-workers-all-the-things/vizicities-worker.js
+++ b/examples/web-workers-all-the-things/vizicities-worker.js
@@ -5,12 +5,12 @@ importScripts('../../dist/vizicities-worker.min.js');
 
 const DEBUG = false;
 
-if (DEBUG) { console.log('Worker started', performance.now()); }
+if (DEBUG) { console.log('Worker started', Date.now()); }
 
 // Send startup message to main thread
 postMessage({
   type: 'startup',
-  payload: performance.now()
+  payload: Date.now()
 });
 
 // Recieve message from main thread
@@ -24,7 +24,7 @@ onmessage = (event) => {
     return;
   }
 
-  var time = performance.now();
+  var time = Date.now();
   if (DEBUG) { console.log('Message received from main thread', time, event.data); }
   // if (DEBUG) console.log('Time to receive message', time - event.data);
 
@@ -50,7 +50,7 @@ onmessage = (event) => {
 
   // Call method with given arguments
   _method.apply(this, event.data.args).then((result) => {
-    console.log('Message sent from worker', performance.now());
+    if (DEBUG) { console.log('Message sent from worker', Date.now()); }
 
     // Return results
     postMessage({

--- a/examples/web-workers-basic/vizicities-worker.js
+++ b/examples/web-workers-basic/vizicities-worker.js
@@ -5,12 +5,12 @@ importScripts('../../dist/vizicities-worker.min.js');
 
 const DEBUG = false;
 
-if (DEBUG) { console.log('Worker started', performance.now()); }
+if (DEBUG) { console.log('Worker started', Date.now()); }
 
 // Send startup message to main thread
 postMessage({
   type: 'startup',
-  payload: performance.now()
+  payload: Date.now()
 });
 
 // Recieve message from main thread
@@ -24,7 +24,7 @@ onmessage = (event) => {
     return;
   }
 
-  var time = performance.now();
+  var time = Date.now();
   if (DEBUG) { console.log('Message received from main thread', time, event.data); }
   // if (DEBUG) console.log('Time to receive message', time - event.data);
 
@@ -50,7 +50,7 @@ onmessage = (event) => {
 
   // Call method with given arguments
   _method.apply(this, event.data.args).then((result) => {
-    console.log('Message sent from worker', performance.now());
+    if (DEBUG) { console.log('Message sent from worker', Date.now()); }
 
     // Return results
     postMessage({

--- a/examples/web-workers-geojson/vizicities-worker.js
+++ b/examples/web-workers-geojson/vizicities-worker.js
@@ -5,12 +5,12 @@ importScripts('../../dist/vizicities-worker.min.js');
 
 const DEBUG = false;
 
-if (DEBUG) { console.log('Worker started', performance.now()); }
+if (DEBUG) { console.log('Worker started', Date.now()); }
 
 // Send startup message to main thread
 postMessage({
   type: 'startup',
-  payload: performance.now()
+  payload: Date.now()
 });
 
 // Recieve message from main thread
@@ -24,7 +24,7 @@ onmessage = (event) => {
     return;
   }
 
-  var time = performance.now();
+  var time = Date.now();
   if (DEBUG) { console.log('Message received from main thread', time, event.data); }
   // if (DEBUG) console.log('Time to receive message', time - event.data);
 
@@ -50,7 +50,7 @@ onmessage = (event) => {
 
   // Call method with given arguments
   _method.apply(this, event.data.args).then((result) => {
-    console.log('Message sent from worker', performance.now());
+    if (DEBUG) { console.log('Message sent from worker', Date.now()); }
 
     // Return results
     postMessage({

--- a/examples/web-workers-outlines/vizicities-worker.js
+++ b/examples/web-workers-outlines/vizicities-worker.js
@@ -5,12 +5,12 @@ importScripts('../../dist/vizicities-worker.min.js');
 
 const DEBUG = false;
 
-if (DEBUG) { console.log('Worker started', performance.now()); }
+if (DEBUG) { console.log('Worker started', Date.now()); }
 
 // Send startup message to main thread
 postMessage({
   type: 'startup',
-  payload: performance.now()
+  payload: Date.now()
 });
 
 // Recieve message from main thread
@@ -24,7 +24,7 @@ onmessage = (event) => {
     return;
   }
 
-  var time = performance.now();
+  var time = Date.now();
   if (DEBUG) { console.log('Message received from main thread', time, event.data); }
   // if (DEBUG) console.log('Time to receive message', time - event.data);
 
@@ -50,7 +50,7 @@ onmessage = (event) => {
 
   // Call method with given arguments
   _method.apply(this, event.data.args).then((result) => {
-    console.log('Message sent from worker', performance.now());
+    if (DEBUG) { console.log('Message sent from worker', Date.now()); }
 
     // Return results
     postMessage({

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "lru-cache": "^4.0.0",
     "reqwest": "^2.0.5",
     "shortid": "^2.2.6",
+    "text-encoding": "^0.6.1",
     "three": "^0.74.0",
     "topojson": "^1.6.24",
     "xhr2": "^0.1.3"

--- a/src/layer/GeoJSONWorkerLayer.js
+++ b/src/layer/GeoJSONWorkerLayer.js
@@ -121,10 +121,10 @@ class GeoJSONWorkerLayer extends Layer {
 
   _execWorker(geojson, topojson, headers, originPoint, style, interactive, pointGeometry, transferrables) {
     return new Promise((resolve, reject) => {
-      console.time('Worker round trip');
+      // console.time('Worker round trip');
 
       Worker.exec('GeoJSONWorkerLayer.Process', [geojson, topojson, headers, originPoint, style, interactive, pointGeometry], transferrables).then((results) => {
-        console.timeEnd('Worker round trip');
+        // console.timeEnd('Worker round trip');
 
         // if (this._aborted) {
         //   resolve();

--- a/src/layer/tile/TileLayer.js
+++ b/src/layer/tile/TileLayer.js
@@ -141,7 +141,7 @@ class TileLayer extends Layer {
       return;
     }
 
-    // var start = performance.now();
+    // var start = (performance || Date).now();
 
     var camera = this._world.getCamera();
 
@@ -220,7 +220,7 @@ class TileLayer extends Layer {
 
     this._tileList = tileList;
 
-    // console.log(performance.now() - start);
+    // console.log((performance || Date).now() - start);
   }
 
   _divide(checkList) {

--- a/src/util/Buffer.js
+++ b/src/util/Buffer.js
@@ -3,6 +3,7 @@
  */
 
 import THREE from 'three';
+import {TextEncoder, TextDecoder} from 'text-encoding';
 
 var Buffer = (function() {
   // Merge TypedArrays of the same type

--- a/src/util/WorkerPool.js
+++ b/src/util/WorkerPool.js
@@ -20,7 +20,7 @@ class WorkerPool {
       }
 
       Promise.all(workerPromises).then(() => {
-        if (DEBUG) { console.log('All workers ready', performance.now()); }
+        if (DEBUG) { console.log('All workers ready', (performance || Date).now()); }
         resolve();
       }).catch(reject);
     });
@@ -35,7 +35,7 @@ class WorkerPool {
 
       // Start worker and wait for it to be ready
       return worker.start().then(() => {
-        if (DEBUG) { console.log('Worker ready', performance.now()); }
+        if (DEBUG) { console.log('Worker ready', (performance || Date).now()); }
 
         // Add worker to pool
         this.workers.push(worker);

--- a/src/util/WorkerPoolWorker.js
+++ b/src/util/WorkerPoolWorker.js
@@ -55,7 +55,7 @@ class WorkerPoolWorker {
   }
 
   onMessage(event) {
-    console.log('Message received from worker', performance.now());
+    if (DEBUG) { console.log('Message received from worker', (performance || Date).now()); }
 
     this.busy = false;
 


### PR DESCRIPTION
## Description

Web Workers ViziCities examples currently don't work in IE and Safari.

## Solution

A polyfill has been added for `TextEncoder` and `TextDecoder` and `performance.now()` has been removed from worker code.