### PR TITLE
Remove remaining image tile mesh references

### DIFF
--- a/src/layer/tile/ImageTileLayer.js
+++ b/src/layer/tile/ImageTileLayer.js
@@ -107,9 +107,8 @@ class ImageTileLayer extends TileLayer {
         setTimeout(() => {
           this._calculateLOD();
           this._initEvents();
+          resolve(this);
         }, 0);
-
-        resolve(this);
       }).catch(reject);
     });
   }
@@ -130,7 +129,7 @@ class ImageTileLayer extends TileLayer {
   }
 
   _onWorldMove(latlon, point) {
-    this._moveBaseLayer(point);
+    // this._moveBaseLayer(point);
   }
 
   _moveBaseLayer(point) {
@@ -150,18 +149,18 @@ class ImageTileLayer extends TileLayer {
     this._throttledWorldUpdate = null;
 
     // Dispose of mesh and materials
-    this._baseLayer.geometry.dispose();
-    this._baseLayer.geometry = null;
+    // this._baseLayer.geometry.dispose();
+    // this._baseLayer.geometry = null;
 
-    if (this._baseLayer.material.map) {
-      this._baseLayer.material.map.dispose();
-      this._baseLayer.material.map = null;
-    }
+    // if (this._baseLayer.material.map) {
+    //   this._baseLayer.material.map.dispose();
+    //   this._baseLayer.material.map = null;
+    // }
 
-    this._baseLayer.material.dispose();
-    this._baseLayer.material = null;
+    // this._baseLayer.material.dispose();
+    // this._baseLayer.material = null;
 
-    this._baseLayer = null;
+    // this._baseLayer = null;
 
     // Run common destruction logic from parent
     super.destroy();


### PR DESCRIPTION
## Description
Currently removing an image tile causes ViziCities to error.

## Solution
Removed sections of code that were causing the issues. I also moved the promise `resolve` into the `setTimeout` to prevent timing errors.