### PR TITLE
Remove attribution on layer removal

### DIFF
--- a/src/World.js
+++ b/src/World.js
@@ -277,6 +277,10 @@ class World extends EventEmitter {
       this._layers.splice(layerIndex, 1);
     };
 
+    if (layer._options.attribution) {
+      this._removeAttribution(layer._options.id);
+    }
+
     if (layer.isOutput() && layer.isOutputToScene()) {
       this._engine._scene.remove(layer._object3D);
       this._engine._domScene3D.remove(layer._domObject3D);


### PR DESCRIPTION
## Description

Attribution messages remain even after layer removal.

## Solution

Call attribution removal method on layer removal from world.