### PR TITLE
Fix world.destroy

### DIFF
--- a/src/World.js
+++ b/src/World.js
@@ -153,7 +153,9 @@ class World extends EventEmitter {
 
   _removeAttribution(id) {
     var elem = document.querySelectorAll('#attribution-container [data-layer="' + id + '"]')[0];
-    elem.remove();
+    if (elem) {
+      elem.remove();
+    }
   }
 
   // Set world view

--- a/src/layer/environment/EnvironmentLayer.js
+++ b/src/layer/environment/EnvironmentLayer.js
@@ -129,9 +129,11 @@ class EnvironmentLayer extends Layer {
   destroy() {
     this._skyboxLight = null;
 
-    this.remove(this._skybox._mesh);
-    this._skybox.destroy();
-    this._skybox = null;
+    if (this._skybox) {
+      this.remove(this._skybox._mesh);
+      this._skybox.destroy();
+      this._skybox = null;
+    }
 
     super.destroy();
   }


### PR DESCRIPTION
## Description

Currently `world.destroy()` errors when ran.

## Solution

Add in conditionals to catch undefined values and prevent errors.